### PR TITLE
fix: Free up space in VM

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -49,7 +49,7 @@ jobs:
           && cd $JKUBE_DIR \
           && git checkout "$JKUBE_REVISION"
       - name: Install JKube
-        run: cd $JKUBE_DIR && mvn -f pom.xml -B -DskipTests clean install
+        run: cd $JKUBE_DIR && mvn -f pom.xml -B -DskipTests clean install && rm -rf $JKUBE_DIR
       - name: Install and Run Integration Tests
         run: |
           cd $JKUBE_DIR \
@@ -65,6 +65,13 @@ jobs:
         openshift: [v3.9.0,v3.11.0]
         suite: ['quarkus','springboot','webapp','other']
     steps:
+      - name: Free up Space
+        run: |
+          sudo apt-get remove -y 'linux-headers.*'
+          sudo apt-get remove -y 'mysql.*'
+          sudo apt-get remove -y 'php.*'
+          sudo apt-get remove -y 'ruby.*'
+          df -h
       - name: Checkout
         uses: actions/checkout@v2.0.0
       - name: Setup OpenShift
@@ -81,10 +88,16 @@ jobs:
           && cd $JKUBE_DIR \
           && git checkout "$JKUBE_REVISION"
       - name: Install JKube
-        run: cd $JKUBE_DIR && mvn -f pom.xml -B -DskipTests clean install
+        run: cd $JKUBE_DIR && mvn -f pom.xml -B -DskipTests clean install && rm -rf $JKUBE_DIR
       - name: Install and Run Integration Tests
         run: |
           cd $JKUBE_DIR \
           && JKUBE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
           && cd .. \
           && ./mvnw -B -POpenShift,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=1
+      - name: Cluster Information
+        if: always()
+        run: |
+          oc login -u system:admin
+          oc describe node localhost
+          oc login -u developer

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/KubernetesClientAssertion.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/KubernetesClientAssertion.java
@@ -15,15 +15,19 @@ package org.eclipse.jkube.integrationtests.assertions;
 
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.client.OpenShiftClient;
 import okhttp3.OkHttpClient;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+import static org.eclipse.jkube.integrationtests.cli.CliUtils.runCommand;
+
 public class KubernetesClientAssertion<T extends KubernetesResource> {
 
-  static final long DEFAULT_AWAIT_TIME_SECONDS = 60L;
+  static final long DEFAULT_AWAIT_TIME_SECONDS = 45L;
 
   private static OkHttpClient okHttpClient;
 
@@ -56,5 +60,38 @@ public class KubernetesClientAssertion<T extends KubernetesResource> {
 
   public String getApplication() {
     return jKubeCase.getApplication();
+  }
+
+  static void printDiagnosis(JKubeCase jKubeCase) throws IOException, InterruptedException {
+    System.err.println("\n\n===========================");
+    System.err.println("\nCurrent PODs:");
+    jKubeCase.getKubernetesClient().pods().list().getItems().forEach(pod -> {
+      System.err.println("\n---------------------------");
+      System.err.println(pod.getMetadata().getName());
+      System.err.println("\nMetadata:");
+      System.err.println(pod.getMetadata());
+      System.err.println("\nStatus:");
+      System.err.println(pod.getStatus());
+      System.err.println("---------------------------");
+    });
+    if (jKubeCase.getKubernetesClient().isAdaptable(OpenShiftClient.class)) {
+      final OpenShiftClient oc = jKubeCase.getKubernetesClient().adapt(OpenShiftClient.class);
+      System.err.println("\n\n===========================");
+      System.err.println("\nDeployment:");
+      System.err.println("\n\nStatus:");
+      System.err.println(oc.deploymentConfigs().withName(jKubeCase.getApplication()).get().getStatus());
+      System.err.println("\n\nStatus Details:");
+      System.err.println(oc.deploymentConfigs().withName(jKubeCase.getApplication()).get().getStatus().getDetails());
+      System.err.println("\n\nStatus Conditions:");
+      oc.deploymentConfigs().withName(jKubeCase.getApplication()).get().getStatus().getConditions().forEach(
+        condition -> System.err.println(condition.toString())
+      );
+    }
+    System.err.println("\n\n===========================");
+    System.err.println("\n\nDisk Space:");
+    System.err.println(runCommand("df -h").getOutput());
+    System.err.println("\n\n===========================");
+    System.err.println("\n\nDisk inodes:");
+    System.err.println(runCommand("df -hi").getOutput());
   }
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/ServiceAssertion.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/ServiceAssertion.java
@@ -20,7 +20,6 @@ import okhttp3.Response;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 import org.hamcrest.Matcher;
 
-import java.net.URL;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfig.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfig.java
@@ -14,9 +14,10 @@
 package org.eclipse.jkube.integrationtests.springboot.zeroconfig;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 import org.eclipse.jkube.integrationtests.maven.BaseMavenCase;
+
+import java.io.IOException;
 
 import static org.eclipse.jkube.integrationtests.assertions.PodAssertion.awaitPod;
 import static org.eclipse.jkube.integrationtests.assertions.ServiceAssertion.awaitService;
@@ -36,7 +37,7 @@ abstract class ZeroConfig extends BaseMavenCase implements JKubeCase {
     return "spring-boot-zero-config";
   }
 
-  final Pod assertThatShouldApplyResources() throws InterruptedException {
+  final Pod assertThatShouldApplyResources() throws InterruptedException, IOException {
     final Pod pod = awaitPod(this)
       .logContains("Started ZeroConfigApplication in", 40)
       .getKubernetesResource();

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/Thorntail.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/Thorntail.java
@@ -14,7 +14,6 @@
 package org.eclipse.jkube.integrationtests.thorntail;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 import org.eclipse.jkube.integrationtests.maven.BaseMavenCase;
 

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/ThorntailOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/ThorntailOcITCase.java
@@ -87,7 +87,7 @@ class ThorntailOcITCase extends Thorntail {
   @DisplayName("oc:resource, should create manifests")
   void ocResource() throws Exception {
     // When
-    final InvocationResult invocationResult = maven("oc:resource");
+    final InvocationResult invocationResult = maven("clean oc:resource"); //Clean to free up DiskSpace
     // Then
     assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
     final File metaInfDirectory = new File(

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/Vertx.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/Vertx.java
@@ -14,7 +14,6 @@
 package org.eclipse.jkube.integrationtests.vertx;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 import org.eclipse.jkube.integrationtests.maven.BaseMavenCase;
 

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxOcITCase.java
@@ -80,7 +80,7 @@ class VertxOcITCase extends Vertx {
   @DisplayName("oc:resource, should create manifests")
   void ocResource() throws Exception {
     // When
-    final InvocationResult invocationResult = maven("oc:resource");
+    final InvocationResult invocationResult = maven("clean oc:resource"); //Clean to free up DiskSpace
     // Then
     assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
     final File metaInfDirectory = new File(

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfig.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfig.java
@@ -14,9 +14,10 @@
 package org.eclipse.jkube.integrationtests.webapp.zeroconfig;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 import org.eclipse.jkube.integrationtests.maven.BaseMavenCase;
+
+import java.io.IOException;
 
 import static org.eclipse.jkube.integrationtests.assertions.PodAssertion.assertPod;
 import static org.eclipse.jkube.integrationtests.assertions.PodAssertion.awaitPod;
@@ -37,7 +38,7 @@ abstract class ZeroConfig extends BaseMavenCase implements JKubeCase {
     return "webapp-zero-config";
   }
 
-  final Pod assertThatShouldApplyResources() throws InterruptedException {
+  final Pod assertThatShouldApplyResources() throws InterruptedException, IOException {
     final Pod pod = awaitPod(this).getKubernetesResource();
     assertPod(pod).apply(this).logContains("Catalina.start Server startup", 10);
     awaitService(this, pod.getMetadata().getNamespace())


### PR DESCRIPTION
Some integration tests fail in OpenShift 3.11 due to `DiskPressue`.

After analyzing and evaluating, tests suites that download more than one image (`other`) are the ones that will most probably be hit by this problem.

Although diagnostics show that there's still plenty of space and inodes free, it seems that there is some threshold (that can't be configured easily) that is surpassed, triggering the error.

In order to prevent this from happening, space is freed in the VM before invoking the test suite.

These changes should be propagated to https://github.com/eclipse/jkube/ integration-tests workflow > https://github.com/eclipse/jkube/pull/89