### PR TITLE
feature: Windows specific cases (No cluster support)

### DIFF
--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -1,0 +1,85 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+name: JKube Windows Specific Tests
+
+on:
+  push:
+#    branches:
+#      - master
+  pull_request:
+
+env:
+  JKUBE_REPOSITORY: https://github.com/eclipse/jkube.git
+  JKUBE_REVISION: master
+  JKUBE_DIR: jkube
+
+jobs:
+  windows:
+    name: Windows
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+      - name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+#      - name: Enable Linux Containers on Windows 2019 Server
+#        run: |
+#          Install-Module "DockerMsftProvider" -Force
+#          Update-Module "DockerMsftProvider"
+#          Install-Package Docker -ProviderName "DockerMsftProvider" -Update -Force
+#          Set-Content -Value "`{`"experimental`":true`}" -Path C:\ProgramData\docker\config\daemon.json
+#          restart-service docker
+#      - name: Download lcow
+#        run: |
+#          mkdir 'C:\Program Files\Linux Containers'
+#          $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } –PassThru
+#          Invoke-WebRequest -Uri 'https://github.com/linuxkit/lcow/releases/download/v4.14.35-v0.3.9/release.zip' -OutFile $tmp
+#          $tmp | Expand-Archive -DestinationPath 'C:\Program Files\Linux Containers' -Force
+#          $tmp | Remove-Item
+#      - name: Set up kind
+#        run: |
+#          choco install kind
+#          kind create cluster
+      - name: Set up VirtualBox
+        run: |
+          choco install virtualbox --params "/NoDesktopShortcut"
+          refreshenv
+      - name: Set up Multipass
+        run: |
+          choco install multipass
+          refreshenv
+          multipass set local.driver=virtualbox
+      - name: Set up MicroK8s
+        run: |
+          multipass launch --name microk8s-vm --mem 4G --disk 40G
+          multipass exec microk8s-vm -- sudo snap install microk8s --classic
+          multipass exec microk8s-vm -- sudo iptables -P FORWARD ACCEPT
+      - name: Checkout JKube Repository
+        run: |
+          git clone $env:JKUBE_REPOSITORY
+          cd $env:JKUBE_DIR
+          git checkout $env:JKUBE_REVISION
+      - name: Install JKube
+        run: |
+          cd $env:JKUBE_DIR
+          mvn -f pom.xml -B -DskipTests clean install
+      - name: Install and Run Integration Tests
+        run: |
+          cd $env:JKUBE_DIR
+          $env:JKUBE_VERSION = (mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression='project.version' -q -DforceStdout) | Out-String
+          cd ..
+          mvn -B -PWindows clean verify -D'jkube.version'=$env:JKUBE_VERSION

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -16,8 +16,8 @@ name: JKube Windows Specific Tests
 
 on:
   push:
-#    branches:
-#      - master
+    branches:
+      - master
   pull_request:
 
 env:
@@ -30,44 +30,16 @@ jobs:
     name: Windows
     runs-on: windows-latest
     steps:
+      - name: Get Windows Version > Used to retrieve specific Docker Image
+        shell: cmd
+        run: |
+          ver
       - name: Checkout
         uses: actions/checkout@v2.0.0
       - name: Setup Java 11
         uses: actions/setup-java@v1
         with:
           java-version: '11'
-#      - name: Enable Linux Containers on Windows 2019 Server
-#        run: |
-#          Install-Module "DockerMsftProvider" -Force
-#          Update-Module "DockerMsftProvider"
-#          Install-Package Docker -ProviderName "DockerMsftProvider" -Update -Force
-#          Set-Content -Value "`{`"experimental`":true`}" -Path C:\ProgramData\docker\config\daemon.json
-#          restart-service docker
-#      - name: Download lcow
-#        run: |
-#          mkdir 'C:\Program Files\Linux Containers'
-#          $tmp = New-TemporaryFile | Rename-Item -NewName { $_ -replace 'tmp$', 'zip' } –PassThru
-#          Invoke-WebRequest -Uri 'https://github.com/linuxkit/lcow/releases/download/v4.14.35-v0.3.9/release.zip' -OutFile $tmp
-#          $tmp | Expand-Archive -DestinationPath 'C:\Program Files\Linux Containers' -Force
-#          $tmp | Remove-Item
-#      - name: Set up kind
-#        run: |
-#          choco install kind
-#          kind create cluster
-      - name: Set up VirtualBox
-        run: |
-          choco install virtualbox --params "/NoDesktopShortcut"
-          refreshenv
-      - name: Set up Multipass
-        run: |
-          choco install multipass
-          refreshenv
-          multipass set local.driver=virtualbox
-      - name: Set up MicroK8s
-        run: |
-          multipass launch --name microk8s-vm --mem 4G --disk 40G
-          multipass exec microk8s-vm -- sudo snap install microk8s --classic
-          multipass exec microk8s-vm -- sudo iptables -P FORWARD ACCEPT
       - name: Checkout JKube Repository
         run: |
           git clone $env:JKUBE_REPOSITORY

--- a/it/pom.xml
+++ b/it/pom.xml
@@ -96,7 +96,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
-              <excludedGroups>OpenShift</excludedGroups>
+              <excludedGroups>OpenShift,Windows</excludedGroups>
             </configuration>
             <executions>
               <execution>
@@ -118,7 +118,29 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
-              <excludedGroups>Kubernetes</excludedGroups>
+              <excludedGroups>Kubernetes,Windows</excludedGroups>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>Windows</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <excludedGroups>Kubernetes,OpenShift</excludedGroups>
             </configuration>
             <executions>
               <execution>

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/Tags.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/Tags.java
@@ -17,6 +17,7 @@ public class Tags {
 
   public static final String KUBERNETES = "Kubernetes";
   public static final String OPEN_SHIFT = "OpenShift";
+  public static final String WINDOWS = "Windows";
 
   private Tags() {}
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/docker/RegistryExtension.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/docker/RegistryExtension.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Store.CloseableResource;
 
+import java.io.File;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.GLOBAL;
 
@@ -31,13 +33,34 @@ public class RegistryExtension implements BeforeAllCallback, CloseableResource {
     if (!started) {
       started = true;
       context.getRoot().getStore(GLOBAL).put("Docker Registry Callback Hook", this);
-      final CliUtils.CliResult dockerRegistry = CliUtils.runCommand("docker run -d -p 5000:5000 --name registry registry:2");
+      final CliUtils.CliResult dockerRegistry;
+      if (isWindows()) {
+        dockerRegistry = startWindowsDockerRegistry();
+      } else {
+        dockerRegistry = startRegularDockerRegistry();
+      }
       assertThat(dockerRegistry.getExitCode(), Matchers.equalTo(0));
+
     }
   }
 
   @Override
   public void close() throws Exception {
     CliUtils.runCommand("docker rm -f registry");
+  }
+
+  private static boolean isWindows() {
+    return System.getProperty("os.name").toLowerCase().startsWith("windows");
+  }
+
+  private static CliUtils.CliResult startRegularDockerRegistry() throws Exception {
+    return CliUtils.runCommand("docker run -d -p 5000:5000 --name registry registry:2");
+  }
+
+  private static CliUtils.CliResult startWindowsDockerRegistry() throws Exception {
+    if (!new File("C:\\registry").mkdirs()) {
+      throw new IllegalStateException("Directory C:\\registry cannot be created");
+    }
+    return CliUtils.runCommand("docker run -d -p 5000:5000 --name registry -v C:\\registry:C:\\registry stefanscherer/registry-windows:2.6.2");
   }
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/maven/BaseMavenCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/maven/BaseMavenCase.java
@@ -70,7 +70,7 @@ public abstract class BaseMavenCase implements MavenProject {
     return maven(goal, new Properties());
   }
 
-  protected final InvocationResult maven(String goal, Properties properties)
+  protected InvocationResult maven(String goal, Properties properties)
     throws IOException, InterruptedException, MavenInvocationException {
 
     return maven(goal, properties, null);

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteDockerITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteDockerITCase.java
@@ -117,6 +117,7 @@ class CompleteDockerITCase extends Complete {
     assertThat(dockerFileContent, containsString("ENTRYPOINT [\"java\",\"-jar\",\"/deployments/spring-boot-complete-0.0.0-SNAPSHOT.jar\"]"));
     assertThat(dockerFileContent, containsString("USER 1000"));
   }
+
   @Test
   @Order(2)
   @ResourceLock(value = SPRINGBOOT_COMPLETE_K8s, mode = READ_WRITE)

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/windows/WindowsITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/windows/WindowsITCase.java
@@ -1,0 +1,48 @@
+package org.eclipse.jkube.integrationtests.windows;
+
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.eclipse.jkube.integrationtests.JKubeCase;
+import org.eclipse.jkube.integrationtests.maven.BaseMavenCase;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.eclipse.jkube.integrationtests.Tags.WINDOWS;
+import static org.eclipse.jkube.integrationtests.assertions.DockerAssertion.assertImageWasRecentlyBuilt;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@Tag(WINDOWS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class WindowsITCase extends BaseMavenCase {
+
+  private static final String PROJECT_ZERO_CONFIG = "projects-to-be-tested/spring-boot/zero-config";
+
+  @Override
+  public String getProject() {
+    return PROJECT_ZERO_CONFIG;
+  }
+
+  @Test
+  @Order(1)
+  @DisplayName("k8s:build, should create image")
+  void k8sBuild() throws Exception {
+    // When
+    final InvocationResult invocationResult = maven("k8s:build");
+    // Then
+    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
+    assertImageWasRecentlyBuilt("integration-tests", "spring-boot-zero-config");
+  }
+
+  @Override
+  protected InvocationResult maven(String goal) throws IOException, InterruptedException, MavenInvocationException {
+    return super.maven(goal, null, ir -> ir.setProfiles(Collections.singletonList("Windows")));
+  }
+}

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/windows/WindowsITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/windows/WindowsITCase.java
@@ -1,8 +1,24 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
 package org.eclipse.jkube.integrationtests.windows;
 
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.MavenInvocationException;
-import org.eclipse.jkube.integrationtests.JKubeCase;
+import org.eclipse.jkube.integrationtests.docker.RegistryExtension;
 import org.eclipse.jkube.integrationtests.maven.BaseMavenCase;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
@@ -11,23 +27,36 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.ExtendWith;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Collections;
+import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Tags.WINDOWS;
 import static org.eclipse.jkube.integrationtests.assertions.DockerAssertion.assertImageWasRecentlyBuilt;
+import static org.eclipse.jkube.integrationtests.assertions.YamlAssertion.yaml;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.aMapWithSize;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.not;
 
 @Tag(WINDOWS)
+@ExtendWith(RegistryExtension.class)
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class WindowsITCase extends BaseMavenCase {
 
-  private static final String PROJECT_ZERO_CONFIG = "projects-to-be-tested/spring-boot/zero-config";
+  private static final String PROJECT_WINDOWS = "projects-to-be-tested\\windows";
 
   @Override
   public String getProject() {
-    return PROJECT_ZERO_CONFIG;
+    return PROJECT_WINDOWS;
   }
 
   @Test
@@ -38,11 +67,116 @@ public class WindowsITCase extends BaseMavenCase {
     final InvocationResult invocationResult = maven("k8s:build");
     // Then
     assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
-    assertImageWasRecentlyBuilt("integration-tests", "spring-boot-zero-config");
+    assertImageWasRecentlyBuilt("integration-tests","windows");
+    final File dockerDirectory = new File(
+      String.format("..\\%s\\target\\docker\\integration-tests\\windows\\latest", getProject()));
+    assertThat(dockerDirectory.exists(), equalTo(true));
+    assertThat(new File(dockerDirectory, "tmp\\docker-build.tar").exists(), equalTo(true));
+    assertThat(new File(dockerDirectory, "build\\maven\\windows-0.0.0-SNAPSHOT.jar").exists(), equalTo(true));
+    assertThat(new File(dockerDirectory, "build\\Dockerfile").exists(), equalTo(true));
+    final String dockerFileContent = String.join("\n",
+      Files.readAllLines(new File(dockerDirectory, "build\\Dockerfile").toPath()));
+    assertThat(dockerFileContent, containsString("FROM mcr.microsoft.com/windows/nanoserver:1809-amd64"));
+  }
+  @Test
+  @Order(2)
+  @DisplayName("k8s:push, should push image to remote registry")
+  void k8sPush() throws Exception {
+    // Given
+    final Properties properties = new Properties();
+    properties.setProperty("docker.push.registry", "localhost:5000");
+    // When
+    final InvocationResult invocationResult = maven("k8s:push", properties);
+    // Then
+    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
+    final Response response = new OkHttpClient.Builder().build().newCall(new Request.Builder()
+      .get().url("http://localhost:5000/v2/integration-tests/windows/tags/list").build())
+      .execute();
+    assertThat(response.body().string(),
+      containsString("{\"name\":\"integration-tests/windows\",\"tags\":[\"latest\"]}"));
+  }
+
+  @Test
+  @Order(3)
+  @DisplayName("k8s:resource, should create manifests")
+  void k8sResource() throws Exception {
+    // When
+    final InvocationResult invocationResult = maven("k8s:resource");
+    // Then
+    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
+    final File metaInfDirectory = new File(
+      String.format("..\\%s\\target\\classes\\META-INF", getProject()));
+    assertThat(metaInfDirectory.exists(), equalTo(true));
+    assertListResource(new File(metaInfDirectory, "jkube\\kubernetes.yml"));
+    assertThat(new File(metaInfDirectory, "jkube\\kubernetes\\windows-deployment.yml"), yaml(not(anEmptyMap())));
+    assertThat(new File(metaInfDirectory, "jkube\\kubernetes\\windows-service.yml"), yaml(not(anEmptyMap())));
+  }
+
+  @Test
+  @Order(4)
+  @DisplayName("oc:resource, should create manifests")
+  void ocResource() throws Exception {
+    // When
+    final InvocationResult invocationResult = maven("oc:resource");
+    // Then
+    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
+    final File metaInfDirectory = new File(
+      String.format("..\\%s\\target\\classes\\META-INF", getProject()));
+    assertThat(metaInfDirectory.exists(), equalTo(true));
+    assertListResource(new File(metaInfDirectory, "jkube\\openshift.yml"));
+    assertThat(new File(metaInfDirectory, "jkube\\openshift\\windows-deploymentconfig.yml"), yaml(not(anEmptyMap())));
+    assertThat(new File(metaInfDirectory, "jkube\\openshift\\windows-route.yml"), yaml(not(anEmptyMap())));
+    assertThat(new File(metaInfDirectory, "jkube\\openshift\\windows-service.yml"), yaml(not(anEmptyMap())));
+  }
+
+  @Test
+  @Order(5)
+  @DisplayName("k8s:helm, should create Helm charts")
+  void k8sHelm() throws Exception {
+    // When
+    final InvocationResult invocationResult = maven("k8s:helm");
+    // Then
+    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
+    assertThat( new File(String.format("..\\%s\\target\\windows-0.0.0-SNAPSHOT-helm.tar.gz", getProject()))
+      .exists(), equalTo(true));
+    final File helmDirectory = new File(
+      String.format("..\\%s\\target\\jkube\\helm\\windows\\kubernetes", getProject()));
+    assertHelm(helmDirectory);
+    assertThat(new File(helmDirectory, "templates\\windows-deployment.yaml"), yaml(not(anEmptyMap())));
+  }
+
+  @Test
+  @Order(6)
+  @DisplayName("oc:helm, should create Helm charts")
+  void ocHelm() throws Exception {
+    // When
+    final InvocationResult invocationResult = maven("oc:helm");
+    // Then
+    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
+    assertThat( new File(String.format("..\\%s\\target\\windows-0.0.0-SNAPSHOT-helmshift.tar.gz", getProject()))
+      .exists(), equalTo(true));
+    final File helmDirectory = new File(
+      String.format("..\\%s\\target\\jkube\\helm\\windows\\openshift", getProject()));
+    assertHelm(helmDirectory);
+    assertThat(new File(helmDirectory, "templates\\windows-deploymentconfig.yaml"), yaml(not(anEmptyMap())));
+    assertThat(new File(helmDirectory, "templates\\windows-route.yaml"), yaml(not(anEmptyMap())));
   }
 
   @Override
-  protected InvocationResult maven(String goal) throws IOException, InterruptedException, MavenInvocationException {
-    return super.maven(goal, null, ir -> ir.setProfiles(Collections.singletonList("Windows")));
+  protected InvocationResult maven(String goal, Properties properties)
+    throws IOException, InterruptedException, MavenInvocationException {
+    return super.maven(goal, properties, ir -> ir.setProfiles(Collections.singletonList("Windows")));
   }
+
+  private static void assertHelm(File helmDirectory) {
+    assertThat(helmDirectory.exists(), equalTo(true));
+    assertThat(new File(helmDirectory, "Chart.yaml"), yaml(allOf(
+      aMapWithSize(3),
+      hasEntry("name", "windows"),
+      hasEntry("description", "Windows Image Build")
+    )));
+    assertThat(new File(helmDirectory, "values.yaml"), yaml(anEmptyMap()));
+    assertThat(new File(helmDirectory, "templates/windows-service.yaml"), yaml(not(anEmptyMap())));
+  }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -370,7 +370,7 @@
     <profile>
       <id>Windows</id>
       <modules>
-        <module>projects-to-be-tested/spring-boot/zero-config</module>
+        <module>projects-to-be-tested/windows</module>
       </modules>
       <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -368,6 +368,25 @@
       </build>
     </profile>
     <profile>
+      <id>Windows</id>
+      <modules>
+        <module>projects-to-be-tested/spring-boot/zero-config</module>
+      </modules>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+            <configuration>
+              <includes>
+                <include>**/integrationtests/windows/**/*ITCase.java</include>
+              </includes>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <!-- Add IT module in a profile so that it gets imported the last and the projects get built first (before tests run) -->
       <id>it-last-module-always-active-hack</id>
       <activation>

--- a/projects-to-be-tested/windows/pom.xml
+++ b/projects-to-be-tested/windows/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jkube.integration-tests</groupId>
+    <artifactId>jkube-integration-tests-project</artifactId>
+    <version>${revision}</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>windows</artifactId>
+  <name>${global.name} :: Windows</name>
+  <description>
+    Windows Image Build
+  </description>
+  <properties>
+    <java.version>11</java.version>
+    <jkube.generator.from>mcr.microsoft.com/windows/nanoserver:1809-amd64</jkube.generator.from>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.5.0</version>
+        <configuration>
+          <mainClass>org.eclipse.jkube.integrationtests.windows.SimpleApplication</mainClass>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>kubernetes-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>openshift-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/projects-to-be-tested/windows/src/main/java/org/eclipse/jkube/integrationtests/windows/SimpleApplication.java
+++ b/projects-to-be-tested/windows/src/main/java/org/eclipse/jkube/integrationtests/windows/SimpleApplication.java
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.windows;
+
+public class SimpleApplication {
+  public static void main(String[] args) {
+    System.out.println("Hello JKube!");
+  }
+}


### PR DESCRIPTION
There's no easy solution to add complete e2e tests for Windows Server 2019 (ephemeral k8s cluster).

Hyper-V is not enabled in GH Actions and enabling requires a VM restart which makes the GH Runner loose the connection to the VM.

Minikube with Virtualbox is not an option either, as it requires vt-x to be enabled (which isn't).

Trying to enable Linux container support doesn't work well and relies on experimental features (lcow project has been archived too), so running alternatives to Minikube (k3s, MicroK8s, etc.) is also impossible.

Current PR will create a Windows Container compatible Docker image and test resource generation.
Tested Eclipse JKube Features:
- build (k8s)
- push (k8s)
- resource (k8s & oc)
- helm (k8s & oc)


Relates to: eclipse/jkube#131