### PR TITLE
feat: windows test verifies docker assembly has files in specified directory

### DIFF
--- a/projects-to-be-tested/windows/pom.xml
+++ b/projects-to-be-tested/windows/pom.xml
@@ -50,10 +50,6 @@
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>kubernetes-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.eclipse.jkube</groupId>
-        <artifactId>openshift-maven-plugin</artifactId>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
This parses the Dockerfile to see where the COPY instruction is reading files from.

This allows to verify that the files exist in that directory in a non-hard-coded way.