### PR TITLE
feat: Improved webapp zero-config tests

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/ServiceAssertion.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/ServiceAssertion.java
@@ -67,6 +67,11 @@ public class ServiceAssertion extends KubernetesClientAssertion<Service> {
     return this;
   }
 
+  public ServiceAssertion assertIsClusterIp() {
+    assertThat(getKubernetesResource().getSpec().getType(), equalTo("ClusterIP"));
+    return this;
+  }
+
   public ServiceAssertion assertIsNodePort() {
     assertThat(getKubernetesResource().getSpec().getType(), equalTo("NodePort"));
     return this;

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     <apache.maven.maven-war-plugin.version>2.6</apache.maven.maven-war-plugin.version>
     <apache.maven-failsafe-plugin.version>3.0.0-M3</apache.maven-failsafe-plugin.version>
     <apache.maven.maven-invoker.version>3.0.1</apache.maven.maven-invoker.version>
-    <fabric8.kubernetes-client.version>4.9.0</fabric8.kubernetes-client.version>
+    <fabric8.kubernetes-client.version>4.9.2</fabric8.kubernetes-client.version>
     <jkube.version>1.0.0-SNAPSHOT</jkube.version>
     <com.fasterxml.jackson.core.version>2.10.0</com.fasterxml.jackson.core.version>
     <com.fasterxml.jackson.dataformat.yaml.version>2.10.0</com.fasterxml.jackson.dataformat.yaml.version>


### PR DESCRIPTION
- Test is compliant for new updated base images (https://github.com/eclipse/jkube/pull/206)
- Service edited and switched to NodePort to verify port response
- Added k8s:log goal verifications
- Updated Kubernetes-Client to 4.9.2 (latest stable)

Relates to:
- https://github.com/eclipse/jkube/pull/206 < **n.b. Tests will only pass when this is merged**
- https://github.com/eclipse/jkube/issues/183