### PR TITLE
fix: remove no longer required workaround config for WilFlySwarm

### DIFF
--- a/projects-to-be-tested/wildflyswarm/rest/pom.xml
+++ b/projects-to-be-tested/wildflyswarm/rest/pom.xml
@@ -79,25 +79,10 @@
       <plugin>
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>kubernetes-maven-plugin</artifactId>
-        <configuration>
-          <resources>
-            <env>
-              <AB_OFF>true</AB_OFF>
-              <JAVA_OPTIONS>-Djava.net.preferIPv4Stack=true</JAVA_OPTIONS>
-            </env>
-          </resources>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>org.eclipse.jkube</groupId>
         <artifactId>openshift-maven-plugin</artifactId>
-        <configuration>
-          <resources>
-            <env>
-              <JAVA_ARGS>-Djava.net.preferIPv4Stack=true</JAVA_ARGS>
-            </env>
-          </resources>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
Remove no longer needed workaround for WildFlySwarm E2E test after fix in https://github.com/eclipse/jkube/pull/209