### PR TITLE
fix: Fix wrong assembly assertions after fixes provided by Karaf implementation

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteDockerITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteDockerITCase.java
@@ -116,7 +116,7 @@ class CompleteDockerITCase extends Complete {
     assertThat(imageFiles, not(hasItem("/deployments/assembly-test/not-considered.txt")));
     assertThat(imageFiles, not(hasItem("/deployments/static/ignored-file.txt")));
     assertThat(imageFiles, hasItem("/deployments/static/static-file.txt"));
-    assertThat(imageFiles, not(hasItem("/deployments/jkube-includes/will-be-included-if-no-assemblies-defined.txt")));
+    assertThat(imageFiles, not(hasItem("/deployments/will-be-included-if-no-assemblies-defined.txt")));
     assertThat(imageFiles, hasItem("/deployments/spring-boot-complete-0.0.0-SNAPSHOT.jar"));
     assertThat(new File(dockerDirectory, "build/Dockerfile").exists(), equalTo(true));
   }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteK8sITCase.java
@@ -93,7 +93,7 @@ class CompleteK8sITCase extends Complete {
       "/deployments");
     assertThat(imageFiles, not(hasItem("/deployments/assembly-test")));
     assertThat(imageFiles, not(hasItem("/deployments/static")));
-    assertThat(imageFiles, hasItem("/deployments/jkube-includes/will-be-included-if-no-assemblies-defined.txt"));
+    assertThat(imageFiles, hasItem("/deployments/will-be-included-if-no-assemblies-defined.txt"));
     assertThat(imageFiles, hasItem("/deployments/spring-boot-complete-0.0.0-SNAPSHOT.jar"));
   }
 


### PR DESCRIPTION
The PR (https://github.com/eclipse/jkube/pull/214) for Karaf Generator fixed some problems with assemblies.

Our current assertions are wrong. This PR fixes assertions to verify valid expected output.