### PR TITLE
fix: webapp tests can be run concurrently

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.12.0,v1.18.2]
+        kubernetes: [v1.12.0,v1.18.3]
         suite: ['quarkus','quarkus-native','springboot','webapp','other']
     steps:
       - name: Checkout
@@ -118,7 +118,7 @@ jobs:
           cd $JKUBE_DIR \
           && JKUBE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
           && cd .. \
-          && ./mvnw -B -POpenShift,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=1
+          && ./mvnw -B -POpenShift,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4
       - name: Save reports as artifact
         if: always()
         uses: actions/upload-artifact@master

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/OpenShift.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/OpenShift.java
@@ -24,10 +24,10 @@ public class OpenShift {
 
   public static void cleanUpCluster(OpenShiftClient oc, JKubeCase jKubeCase) {
     oc.imageStreams().withName(jKubeCase.getApplication()).delete();
-    oc.builds().withLabel("buildconfig", jKubeCase.getApplication()+S2I_BUILD_SUFFIX).delete();
-    oc.buildConfigs().withName(jKubeCase.getApplication()+S2I_BUILD_SUFFIX).delete();
+    oc.builds().withLabel("buildconfig", jKubeCase.getApplication() + S2I_BUILD_SUFFIX).delete();
+    oc.buildConfigs().withName(jKubeCase.getApplication() + S2I_BUILD_SUFFIX).delete();
     oc.pods().withLabel(OPENSHIFT_BUILD_LABEL).list().getItems().stream()
-      .filter(p -> p.getMetadata().getLabels().get(OPENSHIFT_BUILD_LABEL).startsWith(jKubeCase.getApplication()+S2I_BUILD_SUFFIX))
+      .filter(p -> p.getMetadata().getLabels().get(OPENSHIFT_BUILD_LABEL).startsWith(jKubeCase.getApplication() + S2I_BUILD_SUFFIX))
       .forEach(p -> oc.resource(p).delete());
   }
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/KubernetesClientAssertion.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/KubernetesClientAssertion.java
@@ -22,18 +22,25 @@ import org.eclipse.jkube.integrationtests.JKubeCase;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 import static org.eclipse.jkube.integrationtests.cli.CliUtils.runCommand;
 
 public class KubernetesClientAssertion<T extends KubernetesResource> {
 
   static final long DEFAULT_AWAIT_TIME_SECONDS = 45L;
+  static final Duration CONNECT_TIMEOUT = Duration.of(20L, ChronoUnit.SECONDS);
+  static final Duration READ_TIMEOUT = Duration.of(30L, ChronoUnit.SECONDS);
 
   private static OkHttpClient okHttpClient;
 
   synchronized static OkHttpClient httpClient() {
     if (okHttpClient == null) {
-      okHttpClient = new OkHttpClient.Builder().build();
+      okHttpClient = new OkHttpClient.Builder()
+        .connectTimeout(CONNECT_TIMEOUT)
+        .readTimeout(READ_TIMEOUT)
+        .build();
     }
     return okHttpClient;
   }
@@ -56,6 +63,14 @@ public class KubernetesClientAssertion<T extends KubernetesResource> {
 
   public KubernetesClient getKubernetesClient() {
     return jKubeCase.getKubernetesClient();
+  }
+
+  public OpenShiftClient getOpenShiftClient() {
+    return getKubernetesClient().adapt(OpenShiftClient.class);
+  }
+
+  public boolean isOpenShiftClient() {
+    return getKubernetesClient().isAdaptable(OpenShiftClient.class);
   }
 
   public String getApplication() {

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/ThorntailOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/ThorntailOcITCase.java
@@ -86,7 +86,7 @@ class ThorntailOcITCase extends Thorntail {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("oc:resource, should create manifests")
   void ocResource() throws Exception {
     // When
@@ -103,7 +103,7 @@ class ThorntailOcITCase extends Thorntail {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
@@ -115,7 +115,7 @@ class ThorntailOcITCase extends Thorntail {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("oc:undeploy, should delete all applied resources")
   void ocUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/Vertx.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/Vertx.java
@@ -39,7 +39,7 @@ abstract class Vertx extends BaseMavenCase implements JKubeCase {
 
   final Pod assertThatShouldApplyResources() throws Exception {
     final Pod pod = awaitPod(this).getKubernetesResource();
-    assertPod(pod).apply(this).logContains("Succeeded in deploying verticle", 10);
+    assertPod(pod).apply(this).logContains("Succeeded in deploying verticle", 60);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertIsNodePort()
       .assertExposed()

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxK8sITCase.java
@@ -142,8 +142,10 @@ class VertxK8sITCase extends Vertx {
     final InvocationResult invocationResult = maven("k8s:log", properties, irc);
     // Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
-    assertThat(baos.toString(StandardCharsets.UTF_8),
-      stringContainsInOrder("Succeeded in deploying verticle"));
+    assertThat(baos.toString(StandardCharsets.UTF_8), stringContainsInOrder(
+      "Vert.x test application is ready",
+      "Succeeded in deploying verticle"
+    ));
   }
 
 

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxOcITCase.java
@@ -86,11 +86,11 @@ class VertxOcITCase extends Vertx {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("oc:resource, should create manifests")
   void ocResource() throws Exception {
     // When
-    final InvocationResult invocationResult = maven("clean oc:resource"); //Clean to free up DiskSpace
+    final InvocationResult invocationResult = maven("oc:resource");
     // Then
     assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
     final File metaInfDirectory = new File(
@@ -103,7 +103,7 @@ class VertxOcITCase extends Vertx {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
@@ -115,7 +115,7 @@ class VertxOcITCase extends Vertx {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("oc:log, should retrieve log")
   void k8sLog() throws Exception {
     // Given
@@ -129,12 +129,14 @@ class VertxOcITCase extends Vertx {
     final InvocationResult invocationResult = maven("oc:log", properties, irc);
     // Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
-    assertThat(baos.toString(StandardCharsets.UTF_8),
-      stringContainsInOrder("Succeeded in deploying verticle"));
+    assertThat(baos.toString(StandardCharsets.UTF_8), stringContainsInOrder(
+      "Vert.x test application is ready",
+      "Succeeded in deploying verticle"
+    ));
   }
 
   @Test
-  @Order(5)
+  @Order(4)
   @DisplayName("oc:undeploy, should delete all applied resources")
   void ocUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/Jetty.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/Jetty.java
@@ -41,7 +41,7 @@ abstract class Jetty extends BaseMavenCase implements JKubeCase {
 
   final Pod assertThatShouldApplyResources() throws Exception {
     final Pod pod = awaitPod(this).getKubernetesResource();
-    assertPod(pod).apply(this).logContains("Server:main: Started", 10);
+    assertPod(pod).apply(this).logContains("Server:main: Started", 60);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertExposed()
       .assertPorts(hasSize(1))

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyK8sITCase.java
@@ -93,7 +93,7 @@ class JettyK8sITCase extends Jetty {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("k8s:resource, should create manifests")
   void k8sResource() throws Exception {
     // When
@@ -109,7 +109,7 @@ class JettyK8sITCase extends Jetty {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
@@ -133,9 +133,8 @@ class JettyK8sITCase extends Jetty {
       )));
   }
 
-
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("k8s:log, should retrieve log")
   void k8sLog() throws Exception {
     // Given
@@ -153,7 +152,7 @@ class JettyK8sITCase extends Jetty {
   }
 
   @Test
-  @Order(5)
+  @Order(4)
   @DisplayName("k8s:undeploy, should delete all applied resources")
   void k8sUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyOcITCase.java
@@ -86,7 +86,7 @@ class JettyOcITCase extends Jetty {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("oc:resource, should create manifests")
   void ocResource() throws Exception {
     // When
@@ -103,7 +103,7 @@ class JettyOcITCase extends Jetty {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
@@ -115,7 +115,7 @@ class JettyOcITCase extends Jetty {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("oc:log, should retrieve log")
   void ocLog() throws Exception {
     // Given
@@ -133,7 +133,7 @@ class JettyOcITCase extends Jetty {
   }
 
   @Test
-  @Order(5)
+  @Order(4)
   @DisplayName("oc:undeploy, should delete all applied resources")
   void ocUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFlyK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFlyK8sITCase.java
@@ -75,7 +75,7 @@ class WildFlyK8sITCase extends WildFly {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("k8s:resource, should create manifests")
   void k8sResource() throws Exception {
     // When
@@ -91,7 +91,7 @@ class WildFlyK8sITCase extends WildFly {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
@@ -116,7 +116,7 @@ class WildFlyK8sITCase extends WildFly {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("k8s:log, should retrieve log")
   void k8sLog() throws Exception {
     // Given
@@ -134,9 +134,8 @@ class WildFlyK8sITCase extends WildFly {
       stringContainsInOrder("Deployed","WildFly","started in "));
   }
 
-
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("k8s:undeploy, should delete all applied resources")
   void k8sUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigK8sITCase.java
@@ -95,7 +95,7 @@ class ZeroConfigK8sITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("k8s:resource, should create manifests")
   void k8sResource() throws Exception {
     // When
@@ -111,7 +111,7 @@ class ZeroConfigK8sITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
@@ -138,7 +138,7 @@ class ZeroConfigK8sITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("Service as NodePort response should return String")
   void testNodePortResponse() throws Exception {
     // Given
@@ -149,7 +149,7 @@ class ZeroConfigK8sITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(5)
+  @Order(3)
   @DisplayName("k8s:log, should retrieve log")
   void k8sLog() throws Exception {
     // Given
@@ -167,7 +167,7 @@ class ZeroConfigK8sITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(6)
+  @Order(4)
   @DisplayName("k8s:undeploy, should delete all applied resources")
   void k8sUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigOcITCase.java
@@ -88,7 +88,7 @@ class ZeroConfigOcITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("oc:resource, should create manifests")
   void ocResource() throws Exception {
     // When
@@ -105,7 +105,7 @@ class ZeroConfigOcITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
@@ -119,7 +119,7 @@ class ZeroConfigOcITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("Service as NodePort response should return String")
   void testNodePortResponse() throws Exception {
     // Given
@@ -130,7 +130,7 @@ class ZeroConfigOcITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(5)
+  @Order(3)
   @DisplayName("oc:log, should retrieve log")
   void ocLog() throws Exception {
     // Given
@@ -148,7 +148,7 @@ class ZeroConfigOcITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(6)
+  @Order(4)
   @DisplayName("oc:undeploy, should delete all applied resources")
   void ocUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/wildflyswarm/WildFlySwarmOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/wildflyswarm/WildFlySwarmOcITCase.java
@@ -86,7 +86,7 @@ class WildFlySwarmOcITCase extends  WildFlySwarm{
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("oc:resource, should create manifests")
   void ocResource() throws Exception {
     // When
@@ -103,7 +103,7 @@ class WildFlySwarmOcITCase extends  WildFlySwarm{
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
@@ -115,7 +115,7 @@ class WildFlySwarmOcITCase extends  WildFlySwarm{
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("oc:log, should retrieve log")
   void ocLog() throws Exception {
     // Given
@@ -133,7 +133,7 @@ class WildFlySwarmOcITCase extends  WildFlySwarm{
   }
 
   @Test
-  @Order(5)
+  @Order(4)
   @DisplayName("oc:undeploy, should delete all applied resources")
   void ocUndeploy() throws Exception {
     // When

--- a/projects-to-be-tested/thorntail/microprofile/pom.xml
+++ b/projects-to-be-tested/thorntail/microprofile/pom.xml
@@ -34,6 +34,7 @@
   </description>
   <properties>
     <failOnMissingWebXml>false</failOnMissingWebXml>
+    <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
   </properties>
 
   <dependencies>
@@ -69,15 +70,6 @@
           <plugin>
             <groupId>org.eclipse.jkube</groupId>
             <artifactId>kubernetes-maven-plugin</artifactId>
-            <configuration>
-              <enricher>
-                <config>
-                  <jkube-service>
-                    <type>NodePort</type>
-                  </jkube-service>
-                </config>
-              </enricher>
-            </configuration>
           </plugin>
         </plugins>
       </build>
@@ -92,15 +84,6 @@
           <plugin>
             <groupId>org.eclipse.jkube</groupId>
             <artifactId>openshift-maven-plugin</artifactId>
-            <configuration>
-              <enricher>
-                <config>
-                  <jkube-service>
-                    <type>NodePort</type>
-                  </jkube-service>
-                </config>
-              </enricher>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/projects-to-be-tested/vertx/simplest/src/main/java/org/eclipse/jkube/integrationtests/vertx/simplest/SimplestEmbedded.java
+++ b/projects-to-be-tested/vertx/simplest/src/main/java/org/eclipse/jkube/integrationtests/vertx/simplest/SimplestEmbedded.java
@@ -21,8 +21,11 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
 import io.vertx.core.http.HttpServerRequest;
 
+import java.util.logging.Logger;
+
 public class SimplestEmbedded extends AbstractVerticle {
 
+  private static final Logger LOG = Logger.getLogger(SimplestEmbedded.class.getName());
   @Override
   public void start(Future<Void> startFuture) {
     Vertx.vertx().createHttpServer()
@@ -34,6 +37,7 @@ public class SimplestEmbedded extends AbstractVerticle {
     return asyncResult -> {
       if (asyncResult.succeeded()) {
         verticleStart.complete();
+        LOG.info("Vert.x test application is ready");
       } else {
         verticleStart.fail(asyncResult.cause());
       }

--- a/projects-to-be-tested/vertx/simplest/src/main/resources/vertx-default-jul-logging.properties
+++ b/projects-to-be-tested/vertx/simplest/src/main/resources/vertx-default-jul-logging.properties
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
+handlers=java.util.logging.ConsoleHandler
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.ConsoleHandler.level=FINEST

--- a/projects-to-be-tested/webapp/wildfly/pom.xml
+++ b/projects-to-be-tested/webapp/wildfly/pom.xml
@@ -81,6 +81,8 @@
       <properties>
         <artifact-suffix>-docker-mode</artifact-suffix>
         <jkube.build.strategy>docker</jkube.build.strategy>
+        <jkube.targetDir>${project.build.outputDirectory}/META-INF/jkube-docker-mode</jkube.targetDir>
+        <jkube.openshiftManifest>${project.basedir}/target/classes/META-INF/jkube-docker-mode/openshift.yml</jkube.openshiftManifest>
       </properties>
     </profile>
   </profiles>


### PR DESCRIPTION
Webapp tests can be run concurrently

Increased number of parallel threads for OpenShift, it seems to work quite well.

Removed order constraints for some of the test-cases