### PR TITLE
Remove image reference from Wildfly Openshift logs

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFlyOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFlyOcITCase.java
@@ -123,7 +123,8 @@ class WildFlyOcITCase extends WildFly {
     //Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
     assertThat(baos.toString(StandardCharsets.UTF_8), stringContainsInOrder(
-      "Running wildfly/wildfly-centos7 image", "JBoss Bootstrap Environment", "Deployed \"ROOT.war\"")
+      "JBoss Bootstrap Environment", "Deployed \"ROOT.war\"", "Http management interface listening on"
+      , "Admin console listening on")
     );
   }
 


### PR DESCRIPTION
Somehow this `Running wildfly/wildfly-centos7 image` line is not showing up in logs.

Older logs(on `1.0.0-alpha-4`):
```
[INFO] oc: INFO Access log is disabled, ignoring configuration.
[INFO] oc: INFO Using PicketBox SSL configuration.
[INFO] oc: INFO Configuring JGroups cluster traffic encryption protocol to SYM_ENCRYPT.
[INFO] oc: WARN Detected missing JGroups encryption configuration, the communication within the cluster WILL NOT be encrypted.
[INFO] oc: WARN No password defined for JGroups cluster. AUTH protocol will be disabled. Please define JGROUPS_CLUSTER_PASSWORD.
[INFO] oc: WARN Service account has insufficient permissions to view pods in kubernetes (HTTP 403). Clustering might be unavailable. Please refer to the documentation for configuration.
[INFO] oc: INFO Configuring JGroups discovery protocol to kubernetes.KUBE_PING
[INFO] oc: INFO Server started in admin mode, CLI script executed during server boot.
[INFO] oc: INFO Running wildfly/wildfly-centos7 image, version 19.0
[INFO] oc: =========================================================================
[INFO] oc:   JBoss Bootstrap Environment
[INFO] oc:   JBOSS_HOME: /opt/wildfly
[INFO] oc:   JAVA: /usr/lib/jvm/java-11/bin/java
[INFO] oc:   JAVA_OPTS:  -server -Xms64m -Xmx512m -XX:MetaspaceSize=96m -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.logmanager,jdk.nashorn.api,com.sun.crypto.provider -Djava.awt.headless=true -javaagent:/opt/jboss/container/jolokia/jolokia.jar=config=/opt/jboss/container/jolokia/etc/jolokia.properties -Xbootclasspath/a:/opt/wildfly/modules/system/layers/base/org/jboss/logmanager/main/jboss-logmanager-2.1.14.Final.jar:/opt/wildfly/modules/system/layers/base/org/glassfish/jakarta/json/main/jakarta.json-1.1.6.jar:/opt/wildfly/modules/system/layers/base/javax/json/api/main/jakarta.json-api-1.1.6.jar:/opt/wildfly/modules/system/layers/base/org/wildfly/common/main/wildfly-common-1.5.2.Final.jar -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dsun.util.logging.disableCallerCheck=true -XX:+UseParallelOldGC -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 -XX:GCTimeRatio=4 -XX:AdaptiveSizePolicyWeight=90 -XX:+ExitOnOutOfMemoryError -Djava.security.egd=file:/dev/./urandom  -Djboss.modules.settings.xml.url=file:///opt/jboss/container/wildfly/s2i/galleon/settings.xml  --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
[INFO] oc: =========================================================================

```
New logs:
```
[INFO] oc: =========================================================================
[INFO] oc:   JBoss Bootstrap Environment
[INFO] oc:   JBOSS_HOME: /opt/jboss/wildfly
[INFO] oc:   JAVA: /usr/lib/jvm/java/bin/java
[INFO] oc:   JAVA_OPTS:  -server -Xms64m -Xmx512m -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=256m -Djava.net.preferIPv4Stack=true -Djboss.modules.system.pkgs=org.jboss.byteman -Djava.awt.headless=true  --add-exports=java.base/sun.nio.ch=ALL-UNNAMED --add-exports=jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports=jdk.unsupported/sun.reflect=ALL-UNNAMED
[INFO] oc: =========================================================================
```
Note that whole header seems to be gone in case of latest SNAPSHOT build