### PR TITLE
fix: Test log retrieval unified

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -63,7 +63,7 @@ jobs:
           && ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION"
       - name: Save reports as artifact
         if: always()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: Test reports (Minikube ${{ matrix.kubernetes }}-${{ matrix.suite }})
           path: ./it/target/jkube-test-report.txt
@@ -124,7 +124,7 @@ jobs:
           && ./mvnw -B -POpenShift,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4
       - name: Save reports as artifact
         if: always()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: Test reports (OpenShift ${{ matrix.openshift }}-${{ matrix.suite }})
           path: ./it/target/jkube-test-report.txt

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/maven/BaseMavenCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/maven/BaseMavenCase.java
@@ -16,13 +16,18 @@ package org.eclipse.jkube.integrationtests.maven;
 import io.fabric8.kubernetes.api.model.Pod;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.MavenInvocationException;
+import org.apache.maven.shared.invoker.PrintStreamHandler;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
@@ -50,7 +55,7 @@ public abstract class BaseMavenCase implements MavenProject {
       .filter(((Predicate<Pod>)(p -> p.getMetadata().getName().endsWith("-build"))).negate())
       .findAny();
     final Function<Pod, Pod> refreshPod = pod ->
-      jKubeCase.getKubernetesClient().pods().withName(pod.getMetadata().getName()).get();
+      jKubeCase.getKubernetesClient().pods().withName(pod.getMetadata().getName()).fromServer().get();
     matchingPod.map(refreshPod).ifPresent(updatedPod ->
       assertThat(updatedPod.getMetadata().getDeletionTimestamp(), notNullValue()));
     assertServiceExists(jKubeCase, equalTo(false));
@@ -64,28 +69,49 @@ public abstract class BaseMavenCase implements MavenProject {
     )));
   }
 
-  protected InvocationResult maven(String goal)
+  protected Properties properties(Map<String, String> propertyMap) {
+    final Properties ret = new Properties();
+    ret.putAll(propertyMap);
+    return ret;
+  }
+
+  protected Properties properties(String key, String value) {
+    return properties(Collections.singletonMap(key, value));
+  }
+
+  protected MavenInvocationResult maven(String goal)
     throws IOException, InterruptedException, MavenInvocationException {
 
     return maven(goal, new Properties());
   }
 
-  protected InvocationResult maven(String goal, Properties properties)
+  protected MavenInvocationResult maven(String goal, Properties properties)
     throws IOException, InterruptedException, MavenInvocationException {
 
     return maven(goal, properties, null);
   }
 
-  protected final InvocationResult maven(String goal, Properties properties, MavenUtils.InvocationRequestCustomizer chainedCustomizer)
+  protected final MavenInvocationResult maven(
+    String goal, Properties properties, MavenUtils.InvocationRequestCustomizer chainedCustomizer)
     throws IOException, InterruptedException, MavenInvocationException {
 
-    return MavenUtils.execute(i -> {
-      i.setBaseDirectory(new File("../"));
-      i.setProjects(Collections.singletonList(getProject()));
-      i.setGoals(Collections.singletonList(goal));
-      i.setProfiles(getProfiles());
-      i.setProperties(properties);
-      Optional.ofNullable(chainedCustomizer).ifPresent(cc -> cc.customize(i));
-    });
+    try (
+      final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+      final PrintStream printStream = new PrintStream(baos)
+    ) {
+      final MavenUtils.InvocationRequestCustomizer recordStdOutCustomizer = invocationRequest ->
+        invocationRequest.setOutputHandler(new PrintStreamHandler(printStream, true));
+      final InvocationResult mavenResult = MavenUtils.execute(i -> {
+        i.setBaseDirectory(new File("../"));
+        i.setProjects(Collections.singletonList(getProject()));
+        i.setGoals(Collections.singletonList(goal));
+        i.setProfiles(getProfiles());
+        i.setProperties(properties);
+        recordStdOutCustomizer.customize(i);
+        Optional.ofNullable(chainedCustomizer).ifPresent(cc -> cc.customize(i));
+      });
+      baos.flush();
+      return new MavenInvocationResult(mavenResult, baos.toString(StandardCharsets.UTF_8));
+    }
   }
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/maven/MavenInvocationResult.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/maven/MavenInvocationResult.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.maven;
+
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.apache.maven.shared.utils.cli.CommandLineException;
+
+public class MavenInvocationResult implements InvocationResult {
+  private final InvocationResult invocationResult;
+  private final String stdOut;
+
+  public MavenInvocationResult(InvocationResult invocationResult, String stdOut) {
+    this.invocationResult = invocationResult;
+    this.stdOut = stdOut;
+  }
+
+  public String getStdOut() {
+    return stdOut;
+  }
+
+  @Override
+  public int getExitCode() {
+    return invocationResult.getExitCode();
+  }
+
+  @Override
+  public CommandLineException getExecutionException() {
+    return invocationResult.getExecutionException();
+  }
+}

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/openliberty/OpenLibertyK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/openliberty/OpenLibertyK8sITCase.java
@@ -17,8 +17,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,11 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
@@ -86,7 +81,7 @@ class OpenLibertyK8sITCase extends OpenLiberty {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("k8s:resource, should create manifests")
   void k8sResource() throws Exception {
     // When
@@ -102,7 +97,7 @@ class OpenLibertyK8sITCase extends OpenLiberty {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
@@ -127,26 +122,18 @@ class OpenLibertyK8sITCase extends OpenLiberty {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("k8s:log, should retrieve log")
   void k8sLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("k8s:log", properties, irc);
+    final MavenInvocationResult invocationResult = maven("k8s:log", properties("jkube.log.follow", "false"));
     // Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
-    assertLog(baos.toString(StandardCharsets.UTF_8));
+    assertLog(invocationResult.getStdOut());
   }
 
-
   @Test
-  @Order(5)
+  @Order(4)
   @DisplayName("k8s:undeploy, should delete all applied resources")
   void k8sUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/openliberty/OpenLibertyOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/openliberty/OpenLibertyOcITCase.java
@@ -18,8 +18,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,11 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
@@ -85,7 +80,7 @@ class OpenLibertyOcITCase extends OpenLiberty {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("oc:resource, should create manifests")
   void ocResource() throws Exception {
     // When
@@ -102,7 +97,7 @@ class OpenLibertyOcITCase extends OpenLiberty {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
@@ -114,25 +109,18 @@ class OpenLibertyOcITCase extends OpenLiberty {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("oc:log, should retrieve log")
   void k8sLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("oc:log", properties, irc);
+    final MavenInvocationResult invocationResult = maven("oc:log", properties("jkube.log.follow", "false"));
     // Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
-    assertLog(baos.toString(StandardCharsets.UTF_8));
+    assertLog(invocationResult.getStdOut());
   }
 
   @Test
-  @Order(5)
+  @Order(4)
   @DisplayName("oc:undeploy, should delete all applied resources")
   void ocUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusK8sITCase.java
@@ -80,7 +80,7 @@ class QuarkusK8sITCase extends Quarkus {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("k8s:resource, should create manifests")
   void k8sResource() throws Exception {
     // When
@@ -96,7 +96,7 @@ class QuarkusK8sITCase extends Quarkus {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @DisplayName("k8s:helm, should create Helm charts")
   void k8sHelm() throws Exception {
     // When
@@ -110,7 +110,7 @@ class QuarkusK8sITCase extends Quarkus {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("k8s:apply, should deploy pod and service")
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @SuppressWarnings("unchecked")
@@ -135,7 +135,7 @@ class QuarkusK8sITCase extends Quarkus {
   }
 
   @Test
-  @Order(5)
+  @Order(4)
   @DisplayName("k8s:undeploy, should delete all applied resources")
   void k8sUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusOcITCase.java
@@ -73,8 +73,7 @@ class QuarkusOcITCase extends Quarkus {
     oc.imageStreams().delete();
     // Given
     hackToPreventNullPointerInRegistryServiceCreateAuthConfig("openjdk:11");
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.build.strategy", "docker"); // S2I doesn't support quarkus yet
+    final Properties properties = properties("jkube.build.strategy", "docker"); // S2I doesn't support quarkus yet
     // When
     final InvocationResult invocationResult = maven("oc:build", properties);
     // Then
@@ -83,12 +82,11 @@ class QuarkusOcITCase extends Quarkus {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("oc:resource, should create manifests")
   void ocResource() throws Exception {
     // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.build.strategy", "docker"); // S2I doesn't support quarkus yet
+    final Properties properties = properties("jkube.build.strategy", "docker"); // S2I doesn't support quarkus yet
     // When
     final InvocationResult invocationResult = maven("oc:resource", properties);
     // Then
@@ -103,7 +101,7 @@ class QuarkusOcITCase extends Quarkus {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @DisplayName("oc:helm, should create Helm charts")
   void ocHelm() throws Exception {
     // When
@@ -118,7 +116,7 @@ class QuarkusOcITCase extends Quarkus {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
@@ -130,7 +128,7 @@ class QuarkusOcITCase extends Quarkus {
   }
 
   @Test
-  @Order(5)
+  @Order(4)
   @DisplayName("oc:undeploy, should delete all applied resources")
   void ocUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigOcITCase.java
@@ -18,8 +18,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,11 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
@@ -86,7 +81,7 @@ class ZeroConfigOcITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("oc:resource, should create manifests")
   void ocResource() throws Exception {
     // When
@@ -103,7 +98,7 @@ class ZeroConfigOcITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @DisplayName("oc:helm, should create Helm charts")
   void ocHelm() throws Exception {
     // When
@@ -120,7 +115,7 @@ class ZeroConfigOcITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(4)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:apply, should deploy pod and service")
   void ocApply() throws Exception {
@@ -134,26 +129,19 @@ class ZeroConfigOcITCase extends ZeroConfig {
   }
 
   @Test
-  @Order(5)
+  @Order(3)
   @DisplayName("oc:log, should retrieve log")
   void ocLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("oc:log", properties, irc);
+    final MavenInvocationResult invocationResult = maven("oc:log", properties("jkube.log.follow", "false"));
     // Then
-    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
-    assertThat(baos.toString(StandardCharsets.UTF_8),
+    assertThat(invocationResult.getExitCode(), equalTo(0));
+    assertThat(invocationResult.getStdOut(),
       stringContainsInOrder("Tomcat started on port(s): 8080", "Started ZeroConfigApplication in", "seconds"));
   }
 
   @Test
-  @Order(6)
+  @Order(4)
   @DisplayName("oc:undeploy, should delete all applied resources")
   void ocUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/ThorntailK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/ThorntailK8sITCase.java
@@ -87,7 +87,7 @@ class ThorntailK8sITCase extends Thorntail {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("k8s:resource, should create manifests")
   void k8sResource() throws Exception {
     // When
@@ -103,7 +103,7 @@ class ThorntailK8sITCase extends Thorntail {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
@@ -132,7 +132,7 @@ class ThorntailK8sITCase extends Thorntail {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("k8s:undeploy, should delete all applied resources")
   void k8sUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/VertxOcITCase.java
@@ -18,8 +18,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,11 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
@@ -118,18 +113,11 @@ class VertxOcITCase extends Vertx {
   @Order(3)
   @DisplayName("oc:log, should retrieve log")
   void k8sLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("oc:log", properties, irc);
+    final MavenInvocationResult invocationResult = maven("oc:log", properties("jkube.log.follow", "false"));
     // Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
-    assertThat(baos.toString(StandardCharsets.UTF_8), stringContainsInOrder(
+    assertThat(invocationResult.getStdOut(), stringContainsInOrder(
       "Vert.x test application is ready",
       "Succeeded in deploying verticle"
     ));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyK8sITCase.java
@@ -17,8 +17,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,19 +29,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.assertDeploymentExists;
 import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.awaitDeployment;
 import static org.eclipse.jkube.integrationtests.assertions.DockerAssertion.assertImageWasRecentlyBuilt;
-import static org.eclipse.jkube.integrationtests.assertions.ServiceAssertion.awaitService;
 import static org.eclipse.jkube.integrationtests.assertions.YamlAssertion.yaml;
 import static org.eclipse.jkube.integrationtests.docker.DockerUtils.listImageFiles;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -137,18 +131,11 @@ class JettyK8sITCase extends Jetty {
   @Order(3)
   @DisplayName("k8s:log, should retrieve log")
   void k8sLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("k8s:log", properties, irc);
+    final MavenInvocationResult invocationResult = maven("k8s:log", properties("jkube.log.follow", "false"));
     // Then
-    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
-    assertLog(baos.toString(StandardCharsets.UTF_8));
+    assertThat(invocationResult.getExitCode(), equalTo(0));
+    assertLog(invocationResult.getStdOut());
   }
 
   @Test

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyOcITCase.java
@@ -13,14 +13,12 @@
  */
 package org.eclipse.jkube.integrationtests.webapp.jetty;
 
-import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,16 +30,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
 import static org.eclipse.jkube.integrationtests.Tags.OPEN_SHIFT;
-import static org.eclipse.jkube.integrationtests.assertions.ServiceAssertion.awaitService;
 import static org.eclipse.jkube.integrationtests.assertions.YamlAssertion.yaml;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
@@ -118,18 +111,11 @@ class JettyOcITCase extends Jetty {
   @Order(3)
   @DisplayName("oc:log, should retrieve log")
   void ocLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("oc:log", properties, irc);
+    final MavenInvocationResult invocationResult = maven("oc:log", properties("jkube.log.follow", "false"));
     // Then
-    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
-    assertLog(baos.toString(StandardCharsets.UTF_8));
+    assertThat(invocationResult.getExitCode(), equalTo(0));
+    assertLog(invocationResult.getStdOut());
   }
 
   @Test

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFlyK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFlyK8sITCase.java
@@ -18,17 +18,19 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
@@ -37,8 +39,14 @@ import static org.eclipse.jkube.integrationtests.assertions.DeploymentAssertion.
 import static org.eclipse.jkube.integrationtests.assertions.DockerAssertion.assertImageWasRecentlyBuilt;
 import static org.eclipse.jkube.integrationtests.assertions.YamlAssertion.yaml;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
 
 @Tag(KUBERNETES)
@@ -119,18 +127,11 @@ class WildFlyK8sITCase extends WildFly {
   @Order(3)
   @DisplayName("k8s:log, should retrieve log")
   void k8sLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("k8s:log ", properties, irc);
+    final MavenInvocationResult invocationResult = maven("k8s:log", properties("jkube.log.follow", "false"));
     // Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
-    assertThat(baos.toString(StandardCharsets.UTF_8),
+    assertThat(invocationResult.getStdOut(),
       stringContainsInOrder("Deployed","WildFly","started in "));
   }
 

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFlyOcDockerModeITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFlyOcDockerModeITCase.java
@@ -14,16 +14,13 @@
 package org.eclipse.jkube.integrationtests.webapp.wildfly;
 
 
-
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
 import org.eclipse.jkube.integrationtests.Tags;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
-
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -34,13 +31,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
@@ -129,18 +122,11 @@ class WildFlyOcDockerModeITCase extends WildFly  {
   @Order(3)
   @DisplayName("oc:log, should retrieve logs")
   void ocLog() throws Exception {
-    //Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
-    //When
-    final InvocationResult invocationResult = maven("oc:log", properties,irc);
-    //Then
+    // When
+    final MavenInvocationResult invocationResult = maven("oc:log", properties("jkube.log.follow", "false"));
+    // Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
-    assertThat(baos.toString(StandardCharsets.UTF_8), allOf(
+    assertThat(invocationResult.getStdOut(), allOf(
       not(containsString("Running wildfly/wildfly-centos7 image")),
       stringContainsInOrder("JBoss Bootstrap Environment", "Deployed \"ROOT.war\"")
     ));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFlyOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFlyOcITCase.java
@@ -18,9 +18,7 @@ import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
-
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -31,23 +29,19 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
+import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
 import static org.eclipse.jkube.integrationtests.Tags.OPEN_SHIFT;
 import static org.eclipse.jkube.integrationtests.assertions.YamlAssertion.yaml;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
-import static org.hamcrest.Matchers.not;
-import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
 
 
 @Tag(OPEN_SHIFT)
@@ -111,18 +105,11 @@ class WildFlyOcITCase extends WildFly {
   @Order(3)
   @DisplayName("oc:log, should retrieve logs")
   void ocLog() throws Exception {
-    //Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
-    //When
-    final InvocationResult invocationResult = maven("oc:log", properties,irc);
-    //Then
+    // When
+    final MavenInvocationResult invocationResult = maven("oc:log", properties("jkube.log.follow", "false"));
+    // Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
-    assertThat(baos.toString(StandardCharsets.UTF_8), stringContainsInOrder(
+    assertThat(invocationResult.getStdOut(), stringContainsInOrder(
       "Running wildfly/wildfly-centos7 image", "JBoss Bootstrap Environment", "Deployed \"ROOT.war\"")
     );
   }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigK8sITCase.java
@@ -18,8 +18,7 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,12 +30,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
@@ -152,18 +147,11 @@ class ZeroConfigK8sITCase extends ZeroConfig {
   @Order(3)
   @DisplayName("k8s:log, should retrieve log")
   void k8sLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("k8s:log", properties, irc);
+    final MavenInvocationResult invocationResult = maven("k8s:log", properties("jkube.log.follow", "false"));
     // Then
-    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
-    assertLog(baos.toString(StandardCharsets.UTF_8));
+    assertThat(invocationResult.getExitCode(), equalTo(0));
+    assertLog(invocationResult.getStdOut());
   }
 
   @Test

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfigOcITCase.java
@@ -20,8 +20,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.maven.shared.invoker.InvocationResult;
-import org.apache.maven.shared.invoker.PrintStreamHandler;
-import org.eclipse.jkube.integrationtests.maven.MavenUtils;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,11 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
-import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.OpenShift.cleanUpCluster;
@@ -133,18 +128,11 @@ class ZeroConfigOcITCase extends ZeroConfig {
   @Order(3)
   @DisplayName("oc:log, should retrieve log")
   void ocLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("oc:log", properties, irc);
+    final MavenInvocationResult invocationResult = maven("oc:log", properties("jkube.log.follow", "false"));
     // Then
-    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
-    assertLog(baos.toString(StandardCharsets.UTF_8));
+    assertThat(invocationResult.getExitCode(), equalTo(0));
+    assertLog(invocationResult.getStdOut());
   }
 
   @Test

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/wildfly/jar/WildflyJarK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/wildfly/jar/WildflyJarK8sITCase.java
@@ -87,7 +87,7 @@ class WildflyJarK8sITCase extends WildflyJar {
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("k8s:resource, should create manifests")
   void k8sResource() throws Exception {
     // When
@@ -103,7 +103,7 @@ class WildflyJarK8sITCase extends WildflyJar {
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
@@ -136,7 +136,7 @@ class WildflyJarK8sITCase extends WildflyJar {
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("k8s:undeploy, should delete all applied resources")
   void k8sUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/wildflyswarm/WildFlySwarmK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/wildflyswarm/WildFlySwarmK8sITCase.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.PrintStreamHandler;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.eclipse.jkube.integrationtests.maven.MavenUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.*;
@@ -81,7 +82,7 @@ class WildFlySwarmK8sITCase extends WildFlySwarm{
   }
 
   @Test
-  @Order(2)
+  @Order(1)
   @DisplayName("k8s:resource, should create manifests")
   void k8sResource() throws Exception {
     // When
@@ -97,7 +98,7 @@ class WildFlySwarmK8sITCase extends WildFlySwarm{
   }
 
   @Test
-  @Order(3)
+  @Order(2)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("k8s:apply, should deploy pod and service")
   @SuppressWarnings("unchecked")
@@ -122,26 +123,18 @@ class WildFlySwarmK8sITCase extends WildFlySwarm{
   }
 
   @Test
-  @Order(4)
+  @Order(3)
   @DisplayName("k8s:log, should retrieve log")
   void k8sLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("k8s:log", properties, irc);
+    final MavenInvocationResult invocationResult = maven("k8s:log", properties("jkube.log.follow", "false"));
     // Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
-    assertLog(baos.toString(StandardCharsets.UTF_8));
+    assertLog(invocationResult.getStdOut());
   }
 
-
   @Test
-  @Order(5)
+  @Order(4)
   @DisplayName("k8s:undeploy, should delete all applied resources")
   void k8sUndeploy() throws Exception {
     // When

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/wildflyswarm/WildFlySwarmOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/wildflyswarm/WildFlySwarmOcITCase.java
@@ -19,6 +19,7 @@ import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.PrintStreamHandler;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.eclipse.jkube.integrationtests.maven.MavenUtils;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -118,18 +119,11 @@ class WildFlySwarmOcITCase extends  WildFlySwarm{
   @Order(3)
   @DisplayName("oc:log, should retrieve log")
   void ocLog() throws Exception {
-    // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.log.follow", "false");
-    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    final MavenUtils.InvocationRequestCustomizer irc = invocationRequest -> {
-      invocationRequest.setOutputHandler(new PrintStreamHandler(new PrintStream(baos), true));
-    };
     // When
-    final InvocationResult invocationResult = maven("oc:log", properties, irc);
+    final MavenInvocationResult invocationResult = maven("oc:log", properties("jkube.log.follow", "false"));
     // Then
     assertThat(invocationResult.getExitCode(), equalTo(0));
-    assertLog(baos.toString(StandardCharsets.UTF_8));
+    assertLog(invocationResult.getStdOut());
   }
 
   @Test

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/windows/WindowsITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/windows/WindowsITCase.java
@@ -20,6 +20,7 @@ import org.apache.maven.shared.invoker.InvocationResult;
 import org.apache.maven.shared.invoker.MavenInvocationException;
 import org.eclipse.jkube.integrationtests.docker.RegistryExtension;
 import org.eclipse.jkube.integrationtests.maven.BaseMavenCase;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer;
@@ -89,8 +90,7 @@ public class WindowsITCase extends BaseMavenCase {
   @DisplayName("k8s:push, should push image to remote registry")
   void k8sPush() throws Exception {
     // Given
-    final Properties properties = new Properties();
-    properties.setProperty("jkube.docker.push.registry", "localhost:5000");
+    final Properties properties = properties("jkube.docker.push.registry", "localhost:5000");
     // When
     final InvocationResult invocationResult = maven("k8s:push", properties);
     // Then
@@ -169,7 +169,7 @@ public class WindowsITCase extends BaseMavenCase {
   }
 
   @Override
-  protected InvocationResult maven(String goal, Properties properties)
+  protected MavenInvocationResult maven(String goal, Properties properties)
     throws IOException, InterruptedException, MavenInvocationException {
     return super.maven(goal, properties, ir -> ir.setProfiles(Collections.singletonList("Windows")));
   }


### PR DESCRIPTION
Provided common method to retrieve logs.

Streams for stdout (log) are always flushed and closed.