### PR TITLE
chore: Bump actions-setup-minikube to v2.0.0

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.0.0
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v1.1.0
+        uses: manusa/actions-setup-minikube@v2.0.0
         with:
           minikube version: v1.12.1
           kubernetes version: ${{ matrix.kubernetes }}


### PR DESCRIPTION
- This version no longer removes Docker Daemon shipped with GH
  environment. Run time should improve.