### PR TITLE
chore: Upgrade actions-setup-minikube to v2.0.1 + -openshift to v1.1.2

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.0.0
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.0.0
+        uses: manusa/actions-setup-minikube@v2.0.1
         with:
           minikube version: v1.13.1
           kubernetes version: ${{ matrix.kubernetes }}
@@ -101,7 +101,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.0.0
       - name: Setup OpenShift
-        uses: manusa/actions-setup-openshift@v1.1.0
+        uses: manusa/actions-setup-openshift@v1.1.2
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Upgrade `manusa/actions-setup-minikube` + `manusa/actions-setup-openshift` to the latest version.

Removes the following warnings caused by [CVE-2020-15228](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w):
```
Warning: The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Warning: The `add-path` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Relates to:
- https://github.com/manusa/actions-setup-minikube/issues/22
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/