### PR TITLE
Fix for Issue #441, Upgrade integ-tests to use WildFly JAR 2 Final release.

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/wildfly/jar/WildflyJar.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/wildfly/jar/WildflyJar.java
@@ -14,19 +14,12 @@
 package org.eclipse.jkube.integrationtests.wildfly.jar;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import org.apache.maven.shared.invoker.InvocationResult;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 import org.eclipse.jkube.integrationtests.maven.BaseMavenCase;
-import org.hamcrest.Matchers;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Properties;
 
 import static org.eclipse.jkube.integrationtests.assertions.PodAssertion.assertPod;
 import static org.eclipse.jkube.integrationtests.assertions.PodAssertion.awaitPod;
 import static org.eclipse.jkube.integrationtests.assertions.ServiceAssertion.awaitService;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -57,15 +50,5 @@ abstract class WildflyJar extends BaseMavenCase implements JKubeCase {
       .assertPort("http", 8080, true)
       .assertNodePortResponse("http", equalTo("JKube from WildFly JAR rocks!"));
     return pod;
-  }
-
-  // TODO: REMOVE package goal invocation
-  // https://github.com/jkubeio/jkube-integration-tests/pull/67#issuecomment-700649202
-  protected void workAroundForLocalMavenRepoIssue() throws Exception{
-    final InvocationResult invocationResult =maven("package", new Properties(), i -> {
-      i.setBaseDirectory(new File(i.getBaseDirectory(), PROJECT_WILDFLY_JAR));
-      i.setProjects(null);
-    });
-    assertThat(invocationResult.getExitCode(), Matchers.equalTo(0));
-  }
+    }
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/wildfly/jar/WildflyJarK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/wildfly/jar/WildflyJarK8sITCase.java
@@ -31,9 +31,6 @@ import org.junit.jupiter.api.parallel.ResourceLock;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
-import java.util.Properties;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
 import static org.eclipse.jkube.integrationtests.Tags.KUBERNETES;
@@ -81,9 +78,7 @@ class WildflyJarK8sITCase extends WildflyJar {
   @Test
   @Order(1)
   @DisplayName("k8s:build, should create image")
-  void k8sBuild() throws Exception {
-    // Given
-    workAroundForLocalMavenRepoIssue();
+    void k8sBuild() throws Exception {
     // When
     final InvocationResult invocationResult = maven("k8s:build");
     // Then

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/wildfly/jar/WildflyJarOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/wildfly/jar/WildflyJarOcITCase.java
@@ -75,9 +75,7 @@ class WildflyJarOcITCase extends WildflyJar {
   @Order(1)
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:build, should create image")
-  void ocBuild() throws Exception {
-    // Given
-    workAroundForLocalMavenRepoIssue();
+    void ocBuild() throws Exception {
     // When
     final InvocationResult invocationResult = maven("oc:build");
     // Then

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <thorntail.version>2.5.0.Final</thorntail.version>
     <vertx.version>3.9.1</vertx.version>
     <vertx.plugin.version>1.0.22</vertx.plugin.version>
-    <wildfly.jar.plugin.version>2.0.0.Final</wildfly.jar.plugin.version>
+    <wildfly.jar.plugin.version>2.0.1.Final</wildfly.jar.plugin.version>
     <wildfly.swarm.version>2018.5.0</wildfly.swarm.version>
     <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>2.0.1.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>
   </properties>


### PR DESCRIPTION
Upgraded both bootable JAR Maven plugin and WildFly.
Removed workaround for the relative path that has been fixed in bootable JAR starting 2.0.0.Final.

Signed-off-by: JF Denise jdenise@redhat.com