### PR TITLE
fix: CI fail-fast, install JKube and persist in ActionsCache

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,8 +26,35 @@ env:
   JKUBE_DIR: jkube
 
 jobs:
+  build-jKube:
+    name: Build JKube
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+      - name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Cache .m2 registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Checkout JKube Repository
+        run: |
+          git clone "$JKUBE_REPOSITORY" \
+          && cd $JKUBE_DIR \
+          && git checkout "$JKUBE_REVISION"
+      - name: Install JKube
+        run: cd $JKUBE_DIR && mvn -f pom.xml -B -DskipTests clean install && rm -rf $JKUBE_DIR
+      - name: Install Integration Tests (Downloads dependencies)
+        run: ./mvnw -B -DskipTests clean install
+
   minikube:
     name: K8S
+    needs: build-jKube
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -37,6 +64,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.0.0
+      - name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Restore cache for .m2 registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.0.1
         with:
@@ -44,17 +81,11 @@ jobs:
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: --force
-      - name: Setup Java 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: '11'
       - name: Checkout JKube Repository
         run: |
           git clone "$JKUBE_REPOSITORY" \
           && cd $JKUBE_DIR \
           && git checkout "$JKUBE_REVISION"
-      - name: Install JKube
-        run: cd $JKUBE_DIR && mvn -f pom.xml -B -DskipTests clean install && rm -rf $JKUBE_DIR
       - name: Install and Run Integration Tests
         run: |
           cd $JKUBE_DIR \
@@ -69,6 +100,7 @@ jobs:
           path: ./it/target/jkube-test-report.txt
   openshift:
     name: OpenShift
+    needs: build-jKube
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -100,28 +132,32 @@ jobs:
           df -h
       - name: Checkout
         uses: actions/checkout@v2.0.0
+      - name: Setup Java 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+      - name: Restore cache for .m2 registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-m2
       - name: Setup OpenShift
         uses: manusa/actions-setup-openshift@v1.1.2
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup Java 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: '11'
       - name: Checkout JKube Repository
         run: |
           git clone "$JKUBE_REPOSITORY" \
           && cd $JKUBE_DIR \
           && git checkout "$JKUBE_REVISION"
-      - name: Install JKube
-        run: cd $JKUBE_DIR && mvn -f pom.xml -B -DskipTests clean install && rm -rf $JKUBE_DIR
       - name: Install and Run Integration Tests
         run: |
           cd $JKUBE_DIR \
           && JKUBE_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
           && cd .. \
-          && ./mvnw -B -POpenShift,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4
+          && ./mvnw -B -POpenShift,${{ matrix.suite }} verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4
       - name: Save reports as artifact
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Port of https://github.com/fabric8io/kubernetes-client/pull/2553 to install JKube for all CI runs and cache the generated artifacts.

There shouldn't be any performance gain. Main reason is to allow tests to fail fast in case there are problems when installing JKube (we are getting many issues when downloading artifacts from maven central).