### PR TITLE
fix : Remove `assertExpose()` from ServiceAssertion

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/ServiceAssertion.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/ServiceAssertion.java
@@ -70,11 +70,6 @@ public class ServiceAssertion extends KubernetesClientAssertion<Service> {
     return assertService(service).apply(jKubeCase);
   }
 
-  public ServiceAssertion assertExposed() {
-    assertThat(getKubernetesResource().getMetadata().getLabels(), hasEntry("expose", "true"));
-    return this;
-  }
-
   public ServiceAssertion assertIsClusterIp() {
     assertThat(getKubernetesResource().getSpec().getType(), equalTo("ClusterIP"));
     return this;

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/dockerfile/SimpleK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/dockerfile/SimpleK8sITCase.java
@@ -182,7 +182,6 @@ class SimpleK8sITCase extends BaseMavenCase implements JKubeCase {
       .logContains("Started Application in", 40)
       .getKubernetesResource();
     awaitService(this, pod.getMetadata().getNamespace())
-      .assertExposed()
       .assertIsNodePort()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, true)

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/dsl/DslK8sGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/dsl/DslK8sGradleITCase.java
@@ -124,7 +124,6 @@ class DslK8sGradleITCase {
       .logContains("May the 4th be with you", 40)
       .getKubernetesResource();
     awaitService(jKubeCase, pod.getMetadata().getNamespace())
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, false);
     awaitDeployment(jKubeCase, pod.getMetadata().getNamespace())

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/dsl/DslOcGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/dsl/DslOcGradleITCase.java
@@ -134,7 +134,6 @@ class DslOcGradleITCase {
       .logContains("May the 4th be with you", 40)
       .getKubernetesResource();
     awaitService(jKubeCase, pod.getMetadata().getNamespace())
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, false);
     awaitDeploymentConfig(jKubeCase, pod.getMetadata().getNamespace())

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/openliberty/OpenLiberty.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/openliberty/OpenLiberty.java
@@ -48,7 +48,6 @@ abstract class OpenLiberty extends BaseMavenCase implements JKubeCase {
       LOG_TIMEOUT);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertIsNodePort()
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("glrpc", 9080, true)
       .assertNodePortResponse("glrpc", equalTo("Hello, World."));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/na7ive/QuarkusNativeK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/na7ive/QuarkusNativeK8sITCase.java
@@ -156,7 +156,6 @@ class QuarkusNativeK8sITCase extends BaseMavenCase implements JKubeCase {
     assertPod(pod).apply(this).logContains("quarkus-native 0.0.0-SNAPSHOT native (powered by Quarkus 2.8.3.Final) started in", 60);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertIsNodePort()
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, true)
       .assertNodePortResponse("http",

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/Quarkus.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/Quarkus.java
@@ -51,7 +51,6 @@ abstract class Quarkus extends BaseMavenCase implements JKubeCase {
     assertPod(pod).apply(this).logContains("quarkus-rest 0.0.0-SNAPSHOT on JVM (powered by Quarkus 2.8.3.Final) started in", 60);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertIsNodePort()
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, true)
       .assertNodePortResponse("http",

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/crd/CustomResourceApp.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/crd/CustomResourceApp.java
@@ -53,7 +53,6 @@ abstract class CustomResourceApp extends BaseMavenCase implements JKubeCase {
     assertFrameworkCustomResourceDefinitionApplied(this);
     assertFrameworkCustomResourcesApplied(this, namespace);
     awaitService(this, namespace)
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, true)
       .assertNodePortResponse("http",

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfig.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfig.java
@@ -51,7 +51,6 @@ abstract class ZeroConfig extends BaseMavenCase implements JKubeCase {
       .logContains("Started ZeroConfigApplication in", 40)
       .getKubernetesResource();
     awaitService(this, pod.getMetadata().getNamespace())
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, false);
     return pod;

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigK8sGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigK8sGradleITCase.java
@@ -147,7 +147,6 @@ class ZeroConfigK8sGradleITCase {
       .logContains("Started ZeroConfigApplication in", 40)
       .getKubernetesResource();
     awaitService(jKubeCase, pod.getMetadata().getNamespace())
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, false);
     awaitDeployment(jKubeCase, pod.getMetadata().getNamespace())

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigOcGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigOcGradleITCase.java
@@ -135,7 +135,6 @@ class ZeroConfigOcGradleITCase {
       .logContains("Started ZeroConfigApplication in", 40)
       .getKubernetesResource();
     awaitService(jKubeCase, pod.getMetadata().getNamespace())
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, false);
     awaitDeploymentConfig(jKubeCase, pod.getMetadata().getNamespace())

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/Thorntail.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/thorntail/Thorntail.java
@@ -42,7 +42,6 @@ abstract class Thorntail extends BaseMavenCase implements JKubeCase {
     assertPod(pod).apply(this).logContains("Deployed \"thorntail-microprofile-0.0.0-SNAPSHOT.war\"", 60);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertIsNodePort()
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, true)
       .assertNodePortResponse("http", equalTo("JKube from Thorntail rocks!"));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/Vertx.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/vertx/Vertx.java
@@ -42,7 +42,6 @@ abstract class Vertx extends BaseMavenCase implements JKubeCase {
     assertPod(pod).apply(this).logContains("Succeeded in deploying verticle", 60);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertIsNodePort()
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, true)
       .assertNodePortResponse("http", equalTo("Hello from JKube!"));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/Jetty.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/Jetty.java
@@ -43,7 +43,6 @@ abstract class Jetty extends BaseMavenCase implements JKubeCase {
     final Pod pod = awaitPod(this).getKubernetesResource();
     assertPod(pod).apply(this).logContains("Server:main: Started", 60);
     awaitService(this, pod.getMetadata().getNamespace())
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, true)
       .assertNodePortResponse("http", containsString("<h2>Eclipse JKube on Jetty rocks!</h2>"));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFly.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/wildfly/WildFly.java
@@ -42,7 +42,6 @@ abstract class WildFly extends BaseMavenCase implements JKubeCase {
     assertPod(pod).apply(this).logContains("Deployed", 60);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertIsNodePort()
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, true)
       .assertNodePortResponse("http", containsString("<h2>Eclipse JKube rocks!!</h2>"));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfig.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/zeroconfig/ZeroConfig.java
@@ -47,7 +47,6 @@ abstract class ZeroConfig extends BaseMavenCase implements JKubeCase {
     final Pod pod = awaitPod(this).getKubernetesResource();
     assertPod(pod).apply(this).logContains("Catalina.start Server startup", 60);
     awaitService(this, pod.getMetadata().getNamespace())
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, false);
     return pod;

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/wildfly/jar/WildflyJar.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/wildfly/jar/WildflyJar.java
@@ -45,7 +45,6 @@ abstract class WildflyJar extends BaseMavenCase implements JKubeCase {
       .logContains("WFLYSRV0025", 15);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertIsNodePort()
-      .assertExposed()
       .assertPorts(hasSize(1))
       .assertPort("http", 8080, true)
       .assertNodePortResponse("http", equalTo("JKube from WildFly JAR rocks!"));


### PR DESCRIPTION
Now that we're removing ExposeEnricher, there is no need to verify
whether generated Service contains `expose: true` label.

Related to https://github.com/eclipse/jkube/pull/1447

Signed-off-by: Rohan Kumar <rohaan@redhat.com>