### PR TITLE
Follow-up to https://github.com/jkubeio/jkube-integration-tests/pull/130

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -28,10 +28,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
       - name: Install Integration Tests (Downloads dependencies)
         run: |
@@ -45,15 +45,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.12.0,v1.20.1]
+        kubernetes: [v1.12.0,v1.20.1,v1.23.3]
         suite: ['quarkus','quarkus-native','springboot','webapp','other','dockerfile']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
       - name: Setup Minikube-Kubernetes
         uses: manusa/actions-setup-minikube@v2.4.3
@@ -64,7 +64,7 @@ jobs:
           start args: --force
       - name: Install and Run Integration Tests
         run: |
-          ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version={{ github.event.inputs.version }}
+          ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version=${{ github.event.inputs.version }}
       - name: Save reports as artifact
         if: always()
         uses: actions/upload-artifact@v2
@@ -105,10 +105,10 @@ jobs:
           df -h
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'adopt'
       - name: Setup OpenShift
         uses: manusa/actions-setup-openshift@v1.1.3
@@ -117,7 +117,7 @@ jobs:
           github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install and Run Integration Tests
         run: |
-          ./mvnw -B -POpenShift,${{ matrix.suite }} verify -Djkube.version={{ github.event.inputs.version }} -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4
+          ./mvnw -B -POpenShift,${{ matrix.suite }} verify -Djkube.version=${{ github.event.inputs.version }} -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4
       - name: Save reports as artifact
         if: always()
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
# Description

Related to https://github.com/eclipse/jkube/issues/1088

+ Add missing `$` to github events version placeholder
+ Use java 17 instead of Java 11
+ Add Kubernetes 1.23.3 to Kubernetes matrix

Signed-off-by: Rohan Kumar <rohaan@redhat.com>