### PR TITLE
feat: gradle global clean runs with JKube provided version

### DIFF
--- a/it/pom.xml
+++ b/it/pom.xml
@@ -57,6 +57,10 @@
       <artifactId>gradle-tooling-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>compile</scope>

--- a/it/src/main/java/org/eclipse/jkube/integrationtests/jupiter/api/extension/GradleExtension.java
+++ b/it/src/main/java/org/eclipse/jkube/integrationtests/jupiter/api/extension/GradleExtension.java
@@ -54,6 +54,8 @@ public class GradleExtension extends BaseExtension implements BeforeAllCallback,
     if (annotation.forwardOutput()) {
       gradleRunner.forwardOutput();
     }
+    final var jKubeGradleRunner = new JKubeGradleRunner(
+      gradleRunner, String.join(":", annotation.project()), projectPath);
     if (!cleanBuild) {
       final List<String> cleanBuildTasks = new ArrayList<>();
       if (annotation.clean()) {
@@ -64,11 +66,10 @@ public class GradleExtension extends BaseExtension implements BeforeAllCallback,
       if (annotation.build()) {
         cleanBuildTasks.add("build");
       }
-      gradleRunner.withArguments(cleanBuildTasks).build();
+      jKubeGradleRunner.tasks(false, false, cleanBuildTasks.toArray(new String[0])).build();
     }
     cleanBuild = true;
     gradleRunner.withArguments(Collections.emptyList());
-    final var jKubeGradleRunner = new JKubeGradleRunner(gradleRunner, String.join(":", annotation.project()), projectPath);
     getStore(context).put("jKubeGradleRunner", jKubeGradleRunner);
     for (Field field : extractFields(context, JKubeGradleRunner.class, f -> Modifier.isStatic(f.getModifiers()))) {
       setFieldValue(field, null, jKubeGradleRunner);

--- a/it/src/main/java/org/eclipse/jkube/integrationtests/jupiter/api/extension/RegistryExtension.java
+++ b/it/src/main/java/org/eclipse/jkube/integrationtests/jupiter/api/extension/RegistryExtension.java
@@ -33,7 +33,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class RegistryExtension extends BaseExtension implements BeforeAllCallback, BeforeEachCallback, AfterAllCallback {
 
-  private static final Logger logger = LoggerFactory.getLogger(RegistryExtension.class);
+  private static final Logger log = LoggerFactory.getLogger(RegistryExtension.class);
   @Override
   ExtensionContext.Namespace getNamespace() {
     return ExtensionContext.Namespace.create(RegistryExtension.class);
@@ -43,7 +43,7 @@ public class RegistryExtension extends BaseExtension implements BeforeAllCallbac
   public void beforeAll(ExtensionContext context) throws Exception {
     final var annotation = context.getRequiredTestClass().getAnnotation(DockerRegistry.class);
     CliUtils.runCommand("docker rm -f " + getName(annotation));
-    logger.debug(() -> "Starting Docker Registry Extension");
+    log.debug(() -> "Starting Docker Registry Extension");
     final CliUtils.CliResult dockerRegistry;
     if (isWindows()) {
       dockerRegistry = startWindowsDockerRegistry(annotation);
@@ -51,7 +51,7 @@ public class RegistryExtension extends BaseExtension implements BeforeAllCallbac
       dockerRegistry = startRegularDockerRegistry(annotation);
     }
     assertThat(dockerRegistry.getOutput(), dockerRegistry.getExitCode(), Matchers.equalTo(0));
-    logger.debug(() -> "Docker Registry started successfully");
+    log.debug(() -> "Docker Registry started successfully");
   }
 
   @Override
@@ -66,18 +66,18 @@ public class RegistryExtension extends BaseExtension implements BeforeAllCallbac
 
   @Override
   public void afterAll(ExtensionContext context) throws Exception {
-    logger.debug(() -> "Closing Docker Registry");
+    log.debug(() -> "Closing Docker Registry");
     CliUtils.runCommand("docker stop " + getName(context.getRequiredTestClass().getAnnotation(DockerRegistry.class)));
   }
 
   private static CliUtils.CliResult startRegularDockerRegistry(DockerRegistry dockerRegistry) throws IOException, InterruptedException {
-    logger.debug(() -> "Starting standard Docker Registry");
+    log.debug(() -> "Starting standard Docker Registry");
     return CliUtils.runCommand("docker run --rm -d -p " + dockerRegistry.port() +":5000 --name " +
       getName(dockerRegistry) + " registry:2");
   }
 
   private static CliUtils.CliResult startWindowsDockerRegistry(DockerRegistry dockerRegistry) throws IOException, InterruptedException {
-    logger.debug(() -> "Starting Windows specific Docker Registry");
+    log.debug(() -> "Starting Windows specific Docker Registry");
     final var registry = new File("C:\\registry");
     if (!registry.exists() && !registry.mkdirs()) {
       throw new IllegalStateException("Directory C:\\registry cannot be created");

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <openliberty.version>21.0.0.6</openliberty.version>
     <openliberty.plugin.version>3.0.1</openliberty.plugin.version>
     <quarkus.version>2.8.3.Final</quarkus.version>
+    <slf4j.version>1.7.36</slf4j.version>
     <spring-boot.version>2.6.7</spring-boot.version>
     <thorntail.version>2.7.0.Final</thorntail.version>
     <vertx.version>4.2.7</vertx.version>
@@ -193,6 +194,11 @@
           <groupId>org.jboss.spec.javax.ws.rs</groupId>
           <artifactId>jboss-jaxrs-api_2.1_spec</artifactId>
           <version>${version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-simple</artifactId>
+        <version>${slf4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
The gradle extensions has an initial clean that is used
to download the dependencies so that later goals can be run
offline. This method wasn't updating the JKube version
with the provided system property.