### PR TITLE
fix: Fix service assertion when the response content contains the '–' character

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/ServiceAssertion.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/ServiceAssertion.java
@@ -119,7 +119,9 @@ public class ServiceAssertion extends KubernetesClientAssertion<Service> {
       .get(KubernetesClientAssertion.DEFAULT_AWAIT_TIME_SECONDS, TimeUnit.SECONDS);
     executor.shutdownNow();
     assertThat(response.body(), notNullValue());
-    assertThat(response.body().string(), responseBodyMatcher);
+    // replacing character `–` with `-` to avoid issue described in
+    // https://github.com/jkubeio/jkube-integration-tests/issues/183
+    assertThat(response.body().string().replace("–", "-"), responseBodyMatcher);
     return this;
   }
 


### PR DESCRIPTION
Fix https://github.com/jkubeio/jkube-integration-tests/issues/183. Somehow, printing the character '–' is killing the test and the whole test suite is marked as succeed but should be failing.
