### PR TITLE
ci : Modify default permissions granted to GITHUB_TOKEN in workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -22,6 +22,9 @@ on:
   schedule:
     - cron: '0 1 * * *' # Every day at 1
 
+permissions:
+  contents: read
+
 env:
   JKUBE_REPOSITORY: https://github.com/eclipse/jkube.git
   JKUBE_REVISION: master

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -17,6 +17,9 @@ name: License Check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   license:
     name: License Check

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -21,6 +21,9 @@ on:
         description: Eclipse JKube version to test
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build-jkube:
     name: Build JKube

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -22,6 +22,9 @@ on:
   schedule:
     - cron: '0 1 * * *' # Everyday at 1
 
+permissions:
+  contents: read
+
 env:
   JKUBE_REPOSITORY: https://github.com/eclipse/jkube.git
   JKUBE_REVISION: master


### PR DESCRIPTION
Related to https://github.com/eclipse/jkube/issues/1767

Set content write to read in GitHub workflows in order to limit permissions granted to GitHub token used in workflows

Signed-off-by: Rohan Kumar <rohaan@redhat.com>