### PR TITLE
ci : Add Harden Runner GitHub action GitHub Action workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -34,15 +34,26 @@ jobs:
     name: Build JKube
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8a1ef77ccd7a6d18b009c8cd833b00f49386b657
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            repo.gradle.org:443
+            repo.maven.apache.org:443
+            repo1.maven.org:443
+            repository.jboss.org:443
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Setup Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e11351903adc86f18bfc6660e4de2911b9fc33b4
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@v3
+        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
         with:
           path: |
             ~/.m2/repository
@@ -71,33 +82,68 @@ jobs:
         suite: ['quarkus','quarkus-native','springboot','webapp','other','dockerfile']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Setup Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e11351903adc86f18bfc6660e4de2911b9fc33b4
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@v3
+        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
         with:
           path: |
             ~/.m2/repository
             ./jkube
           key: cache-it-${{ github.run_id }}
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.7.2
+        uses: manusa/actions-setup-minikube@1e9b544a8e64993bad1693f0aebeb108b459edd0
         with:
           minikube version: v1.25.2
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: --force
+      - name: Harden Runner
+        uses: step-security/harden-runner@8a1ef77ccd7a6d18b009c8cd833b00f49386b657
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            azure.archive.ubuntu.com:80
+            cdn03.quay.io:443
+            gcr.io:443
+            github.com:443
+            jcenter.bintray.com:443
+            k8s.gcr.io:443
+            maven.repository.redhat.com:443
+            md-hdd-51w5snc21ccf.z49.blob.storage.azure.net:443
+            md-hdd-bfh3mwcdlxsh.z21.blob.storage.azure.net:443
+            md-hdd-dxgvrxd2cnjf.z22.blob.storage.azure.net:443
+            objects.githubusercontent.com:443
+            packages.microsoft.com:443
+            plugins-artifacts.gradle.org:443
+            plugins.gradle.org:443
+            ppa.launchpadcontent.net:443
+            ppa.launchpad.net:80
+            production.cloudflare.docker.com:443
+            quay.io:443
+            registry-1.docker.io:443
+            registry.access.redhat.com:443
+            registry.k8s.io:443
+            repo1.maven.org:443
+            repo.maven.apache.org:443
+            repository.jboss.org:443
+            storage.googleapis.com:443
+            us-south1-docker.pkg.dev:443
+            us-west2-docker.pkg.dev:443
+            us-east4-docker.pkg.dev:443
       - name: Install and Run Integration Tests
         run: |
           JKUBE_VERSION=$(./mvnw -q -f 'jkube/pom.xml' -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
           && ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION"
       - name: Save reports as artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: Test reports (Minikube ${{ matrix.kubernetes }}-${{ matrix.suite }})
           path: ./it/target/jkube-test-report.txt
@@ -112,33 +158,68 @@ jobs:
         suite: ['quarkus','quarkus-native','springboot','webapp','other','dockerfile']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Setup Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e11351903adc86f18bfc6660e4de2911b9fc33b4
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@v3
+        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
         with:
           path: |
             ~/.m2/repository
             ./jkube
           key: cache-it-${{ github.run_id }}
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.7.2
+        uses: manusa/actions-setup-minikube@1e9b544a8e64993bad1693f0aebeb108b459edd0
         with:
           minikube version: v1.25.2
           kubernetes version: v1.12.10
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: --force
+      - name: Harden Runner
+        uses: step-security/harden-runner@8a1ef77ccd7a6d18b009c8cd833b00f49386b657
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            azure.archive.ubuntu.com:80
+            cdn03.quay.io:443
+            gcr.io:443
+            github.com:443
+            jcenter.bintray.com:443
+            k8s.gcr.io:443
+            maven.repository.redhat.com:443
+            md-hdd-51w5snc21ccf.z49.blob.storage.azure.net:443
+            md-hdd-bfh3mwcdlxsh.z21.blob.storage.azure.net:443
+            md-hdd-dxgvrxd2cnjf.z22.blob.storage.azure.net:443
+            objects.githubusercontent.com:443
+            packages.microsoft.com:443
+            plugins-artifacts.gradle.org:443
+            plugins.gradle.org:443
+            ppa.launchpadcontent.net:443
+            ppa.launchpad.net:80
+            production.cloudflare.docker.com:443
+            quay.io:443
+            registry-1.docker.io:443
+            registry.access.redhat.com:443
+            registry.k8s.io:443
+            repo1.maven.org:443
+            repo.maven.apache.org:443
+            repository.jboss.org:443
+            storage.googleapis.com:443
+            us-south1-docker.pkg.dev:443
+            us-west2-docker.pkg.dev:443
+            us-east4-docker.pkg.dev:443
       - name: Install and Run Integration Tests
         run: |
           JKUBE_VERSION=$(./mvnw -q -f 'jkube/pom.xml' -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
           && ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION"
       - name: Save reports as artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: Test reports (Minikube ${{ matrix.kubernetes }}-${{ matrix.suite }})
           path: ./it/target/jkube-test-report.txt
@@ -153,6 +234,11 @@ jobs:
         openshift: [v3.11.0,v3.10.0]
         suite: ['quarkus','springboot','webapp','other']
     steps:
+#     This seems to cause problems with OpenShift Setup Action 
+#     - name: Harden Runner
+#       uses: step-security/harden-runner@8a1ef77ccd7a6d18b009c8cd833b00f49386b657
+#       with:
+#         egress-policy: audit
       - name: Free up Space
 #            'linux-headers.*'                       \ # Takes > 2 minutes
 #            'google-cloud.*'                        \
@@ -175,21 +261,23 @@ jobs:
           sudo apt-get autoremove
           df -h
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Setup Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e11351903adc86f18bfc6660e4de2911b9fc33b4
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@v3
+        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
         with:
           path: |
             ~/.m2/repository
             ./jkube
           key: cache-it-${{ github.run_id }}
+      - name: Check Docker Status
+        run: systemctl status docker.service    
       - name: Setup OpenShift
-        uses: manusa/actions-setup-openshift@v1.1.4
+        uses: manusa/actions-setup-openshift@4fbc3dc0710ea1f9ff4c7e1e6196dafac8e78a28
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}
@@ -199,7 +287,7 @@ jobs:
           && ./mvnw -B -POpenShift,${{ matrix.suite }} verify -Djkube.version="$JKUBE_VERSION" -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4
       - name: Save reports as artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: Test reports (OpenShift ${{ matrix.openshift }}-${{ matrix.suite }})
           path: ./it/target/jkube-test-report.txt

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -25,10 +25,18 @@ jobs:
     name: License Check
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8a1ef77ccd7a6d18b009c8cd833b00f49386b657
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            repo1.maven.org:443
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Setup Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e11351903adc86f18bfc6660e4de2911b9fc33b4
         with:
           java-version: '11'
           distribution: 'temurin'

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -29,10 +29,45 @@ jobs:
     name: Build JKube
     runs-on: ubuntu-latest
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8a1ef77ccd7a6d18b009c8cd833b00f49386b657
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            azure.archive.ubuntu.com:80
+            cdn03.quay.io:443
+            gcr.io:443
+            github.com:443
+            jcenter.bintray.com:443
+            k8s.gcr.io:443
+            maven.repository.redhat.com:443
+            md-hdd-51w5snc21ccf.z49.blob.storage.azure.net:443
+            md-hdd-bfh3mwcdlxsh.z21.blob.storage.azure.net:443
+            md-hdd-dxgvrxd2cnjf.z22.blob.storage.azure.net:443
+            objects.githubusercontent.com:443
+            packages.microsoft.com:443
+            plugins-artifacts.gradle.org:443
+            plugins.gradle.org:443
+            ppa.launchpadcontent.net:443
+            ppa.launchpad.net:80
+            production.cloudflare.docker.com:443
+            quay.io:443
+            registry-1.docker.io:443
+            registry.access.redhat.com:443
+            registry.k8s.io:443
+            repo1.maven.org:443
+            repo.maven.apache.org:443
+            repository.jboss.org:443
+            storage.googleapis.com:443
+            us-south1-docker.pkg.dev:443
+            us-west2-docker.pkg.dev:443
+            us-east4-docker.pkg.dev:443
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Setup Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e11351903adc86f18bfc6660e4de2911b9fc33b4
         with:
           java-version: '11'
           distribution: 'temurin'
@@ -52,25 +87,60 @@ jobs:
         suite: ['quarkus','quarkus-native','springboot','webapp','other','dockerfile']
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Setup Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e11351903adc86f18bfc6660e4de2911b9fc33b4
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@v2.7.2
+        uses: manusa/actions-setup-minikube@1e9b544a8e64993bad1693f0aebeb108b459edd0
         with:
           minikube version: v1.25.2
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: --force
+      - name: Harden Runner
+        uses: step-security/harden-runner@8a1ef77ccd7a6d18b009c8cd833b00f49386b657
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            auth.docker.io:443
+            azure.archive.ubuntu.com:80
+            cdn03.quay.io:443
+            gcr.io:443
+            github.com:443
+            jcenter.bintray.com:443
+            k8s.gcr.io:443
+            maven.repository.redhat.com:443
+            md-hdd-51w5snc21ccf.z49.blob.storage.azure.net:443
+            md-hdd-bfh3mwcdlxsh.z21.blob.storage.azure.net:443
+            md-hdd-dxgvrxd2cnjf.z22.blob.storage.azure.net:443
+            objects.githubusercontent.com:443
+            packages.microsoft.com:443
+            plugins-artifacts.gradle.org:443
+            plugins.gradle.org:443
+            ppa.launchpadcontent.net:443
+            ppa.launchpad.net:80
+            production.cloudflare.docker.com:443
+            quay.io:443
+            registry-1.docker.io:443
+            registry.access.redhat.com:443
+            registry.k8s.io:443
+            repo1.maven.org:443
+            repo.maven.apache.org:443
+            repository.jboss.org:443
+            storage.googleapis.com:443
+            us-south1-docker.pkg.dev:443
+            us-west2-docker.pkg.dev:443
+            us-east4-docker.pkg.dev:443
       - name: Install and Run Integration Tests
         run: |
           ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version=${{ github.event.inputs.version }}
       - name: Save reports as artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: Test reports (Minikube ${{ matrix.kubernetes }}-${{ matrix.suite }})
           path: ./it/target/jkube-test-report.txt
@@ -85,6 +155,11 @@ jobs:
         openshift: [v3.9.0,v3.11.0]
         suite: ['quarkus','springboot','webapp','other']
     steps:
+#     This seems to cause problems with OpenShift Setup Action 
+#     - name: Harden Runner
+#       uses: step-security/harden-runner@8a1ef77ccd7a6d18b009c8cd833b00f49386b657
+#       with:
+#         egress-policy: audit
       - name: Free up Space
 #            'linux-headers.*'                       \ # Takes > 2 minutes
 #            'google-cloud.*'                        \
@@ -107,14 +182,14 @@ jobs:
           sudo apt-get autoremove
           df -h
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Setup Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e11351903adc86f18bfc6660e4de2911b9fc33b
         with:
           java-version: '11'
           distribution: 'temurin'
       - name: Setup OpenShift
-        uses: manusa/actions-setup-openshift@v1.1.4
+        uses: manusa/actions-setup-openshift@4fbc3dc0710ea1f9ff4c7e1e6196dafac8e78a28
         with:
           oc version: ${{ matrix.openshift }}
           github token: ${{ secrets.GITHUB_TOKEN }}
@@ -123,7 +198,7 @@ jobs:
           ./mvnw -B -POpenShift,${{ matrix.suite }} verify -Djkube.version=${{ github.event.inputs.version }} -Djunit.jupiter.execution.parallel.config.fixed.parallelism=4
       - name: Save reports as artifact
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@65d862660abb392b8c4a3d1195a2108db131dd05
         with:
           name: Test reports (OpenShift ${{ matrix.openshift }}-${{ matrix.suite }})
           path: ./it/target/jkube-test-report.txt

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -40,9 +40,9 @@ jobs:
         run: |
           ver
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - name: Setup Java 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@e11351903adc86f18bfc6660e4de2911b9fc33b4
         with:
           java-version: '11'
           distribution: 'temurin'


### PR DESCRIPTION
# Description
+ Add [Harden Runner](https://github.com/step-security/harden-runner) E2E Tests, Smoke Tests and License GitHub actions. This action is only applicable to Ubuntu based workflows, so it doesn't work for Windows actions.
  - I've commented out Harden Runner action declaration for OpenShift E2E tests because it's declaration seems to cause problems with setting up OpenShift cluster (even in `audit` mode).
+ Use latest commit SHA for Harden Runner
+ Pin all GitHub action steps to full length commit SHA, as directed in [GitHub docs](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

Signed-off-by: Rohan Kumar <rohaan@redhat.com>