### PR TITLE
test : Update Helm archive path in Helm related assertions

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/dsl/DslK8sGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/dsl/DslK8sGradleITCase.java
@@ -102,11 +102,9 @@ class DslK8sGradleITCase implements JKubeCase {
     // When
     gradle.tasks("k8sHelm").build();
     // Then
-    assertThat(gradle.getModulePath().resolve("build")
-        .resolve(getApplication() + "-0.0.0-SNAPSHOT-helm.tar.gz").toFile(),
-      anExistingFile());
     final var helmDirectory = gradle.getModulePath().resolve("build").resolve("jkube")
       .resolve("helm").resolve(getApplication()).resolve("kubernetes");
+    assertThat(helmDirectory.resolve(getApplication() + "-0.0.0-SNAPSHOT.tar.gz").toFile(), anExistingFile());
     assertThat(helmDirectory.resolve("Chart.yaml").toFile(), yaml(allOf(
       aMapWithSize(3),
       hasEntry("apiVersion", "v1"),

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/dsl/DslOcGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/dsl/DslOcGradleITCase.java
@@ -110,11 +110,10 @@ class DslOcGradleITCase implements JKubeCase, OpenShiftCase {
     // When
     gradle.tasks("ocHelm").build();
     // Then
-    assertThat(gradle.getModulePath().resolve("build")
-        .resolve(getApplication() + "-0.0.0-SNAPSHOT-helmshift.tar.gz").toFile(),
-      anExistingFile());
     final var helmDirectory = gradle.getModulePath().resolve("build").resolve("jkube")
       .resolve("helm").resolve(getApplication()).resolve("openshift");
+    assertThat(helmDirectory.resolve(getApplication() + "-0.0.0-SNAPSHOT.tar.gz").toFile(),
+      anExistingFile());
     assertThat(helmDirectory.resolve("Chart.yaml").toFile(), yaml(allOf(
       aMapWithSize(3),
       hasEntry("apiVersion", "v1"),

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/helmconfig/HelmConfigITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/helmconfig/HelmConfigITCase.java
@@ -80,7 +80,7 @@ class HelmConfigITCase implements MavenCase {
     final InvocationResult invocationResult = maven("k8s:helm");
     // Then
     assertInvocation(invocationResult);
-    assertThat(new File(String.format("../%s/target/This is the chart name-1.0-KUBERNETES-helm.tar", getProject()))
+    assertThat(new File(String.format("../%s/target/jkube/helm/This is the chart name/kubernetes/This is the chart name-1.0-KUBERNETES.tar", getProject()))
       .exists(), equalTo(true));
     final File helmDirectory = new File(
       String.format("../%s/target/jkube/helm/This is the chart name/kubernetes", getProject()));
@@ -117,7 +117,7 @@ class HelmConfigITCase implements MavenCase {
     final InvocationResult invocationResult = maven("oc:helm");
     // Then
     assertInvocation(invocationResult);
-    assertThat(new File(String.format("../%s/target/different-name-for-oc-0.1-OC-helmshift.zip", getProject()))
+    assertThat(new File(String.format("../%s/target/jkube/helm/different-name-for-oc/openshift/different-name-for-oc-0.1-OC.zip", getProject()))
       .exists(), equalTo(true));
     final File helmDirectory = new File(
       String.format("../%s/target/jkube/helm/different-name-for-oc/openshift", getProject()));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigK8sGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigK8sGradleITCase.java
@@ -109,11 +109,10 @@ class ZeroConfigK8sGradleITCase extends ZeroConfig {
     // When
     gradle.tasks("k8sHelm").build();
     // Then
-    assertThat(gradle.getModulePath().resolve("build")
-        .resolve(getApplication() + "-0.0.0-SNAPSHOT-helm.tar.gz").toFile(),
-      anExistingFile());
     final var helmDirectory = gradle.getModulePath().resolve("build").resolve("jkube")
       .resolve("helm").resolve(getApplication()).resolve("kubernetes");
+    assertThat(helmDirectory.resolve(getApplication() + "-0.0.0-SNAPSHOT.tar.gz").toFile(),
+      anExistingFile());
     assertThat(helmDirectory.resolve("Chart.yaml").toFile(), yaml(allOf(
       aMapWithSize(3),
       hasEntry("apiVersion", "v1"),

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigK8sITCase.java
@@ -115,7 +115,7 @@ class ZeroConfigK8sITCase extends ZeroConfig implements MavenCase {
     final InvocationResult invocationResult = maven("k8s:helm");
     // Then
     assertInvocation(invocationResult);
-    assertThat( new File(String.format("../%s/target/%s-0.0.0-SNAPSHOT-helm.tar.gz", getProject(), getApplication()))
+    assertThat( new File(String.format("../%s/target/jkube/helm/%s/kubernetes/%s-0.0.0-SNAPSHOT.tar.gz", getProject(), getApplication(), getApplication()))
       .exists(), equalTo(true));
     final File helmDirectory = new File(
       String.format("../%s/target/jkube/helm/%s/kubernetes", getProject(), getApplication()));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigOcGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigOcGradleITCase.java
@@ -100,11 +100,10 @@ class ZeroConfigOcGradleITCase extends ZeroConfig implements OpenShiftCase {
     // When
     gradle.tasks("ocHelm").build();
     // Then
-    assertThat(gradle.getModulePath().resolve("build")
-        .resolve(getApplication() + "-0.0.0-SNAPSHOT-helmshift.tar.gz").toFile(),
-      anExistingFile());
     final var helmDirectory = gradle.getModulePath().resolve("build").resolve("jkube")
       .resolve("helm").resolve(getApplication()).resolve("openshift");
+    assertThat(helmDirectory.resolve(getApplication() + "-0.0.0-SNAPSHOT.tar.gz").toFile(),
+      anExistingFile());
     assertThat(helmDirectory.resolve("Chart.yaml").toFile(), yaml(allOf(
       aMapWithSize(3),
       hasEntry("apiVersion", "v1"),

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/zeroconfig/ZeroConfigOcITCase.java
@@ -93,7 +93,7 @@ class ZeroConfigOcITCase extends ZeroConfig implements MavenCase, OpenShiftCase 
     final InvocationResult invocationResult = maven("oc:helm");
     // Then
     assertInvocation(invocationResult);
-    assertThat( new File(String.format("../%s/target/%s-0.0.0-SNAPSHOT-helmshift.tar.gz", getProject(), getApplication()))
+    assertThat( new File(String.format("../%s/target/jkube/helm/%s/openshift/%s-0.0.0-SNAPSHOT.tar.gz", getProject(), getApplication(), getApplication()))
       .exists(), equalTo(true));
     final File helmDirectory = new File(
       String.format("../%s/target/jkube/helm/%s/openshift", getProject(), getApplication()));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/windows/WindowsITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/windows/WindowsITCase.java
@@ -145,10 +145,10 @@ class WindowsITCase implements MavenCase {
     final InvocationResult invocationResult = maven("k8s:helm");
     // Then
     assertInvocation(invocationResult);
-    assertThat( new File(String.format("..\\%s\\target\\windows-0.0.0-SNAPSHOT-helm.tar.gz", getProject()))
-      .exists(), equalTo(true));
     final File helmDirectory = new File(
       String.format("..\\%s\\target\\jkube\\helm\\windows\\kubernetes", getProject()));
+    assertThat(new File(helmDirectory, "windows-0.0.0-SNAPSHOT.tar.gz")
+      .exists(), equalTo(true));
     assertHelm(helmDirectory);
     assertThat(new File(helmDirectory, "templates\\windows-deployment.yaml"), yaml(not(anEmptyMap())));
   }
@@ -161,10 +161,10 @@ class WindowsITCase implements MavenCase {
     final InvocationResult invocationResult = maven("oc:helm");
     // Then
     assertInvocation(invocationResult);
-    assertThat( new File(String.format("..\\%s\\target\\windows-0.0.0-SNAPSHOT-helmshift.tar.gz", getProject()))
-      .exists(), equalTo(true));
     final File helmDirectory = new File(
       String.format("..\\%s\\target\\jkube\\helm\\windows\\openshift", getProject()));
+    assertThat(new File(helmDirectory, "windows-0.0.0-SNAPSHOT.tar.gz")
+      .exists(), equalTo(true));
     assertHelm(helmDirectory);
     assertThat(new File(helmDirectory, "templates\\windows-deploymentconfig.yaml"), yaml(not(anEmptyMap())));
     assertThat(new File(helmDirectory, "templates\\windows-route.yaml"), yaml(not(anEmptyMap())));


### PR DESCRIPTION
Related to eclipse/jkube#1369

eclipse/jkube#2036 removes trailing classifier
suffixes from generated Helm Archives. It also changes the default
location where Helm Archive is generated. Update E2E tests to accomodate
this change.

Signed-off-by: Rohan Kumar <rohaan@redhat.com>