### PR TITLE
chore (deps) : revert actions/cache bump to latest revision (#243)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -53,7 +53,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812
+        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
         with:
           path: |
             ~/.m2/repository
@@ -89,7 +89,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812
+        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
         with:
           path: |
             ~/.m2/repository
@@ -165,7 +165,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812
+        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
         with:
           path: |
             ~/.m2/repository
@@ -268,7 +268,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@6998d139ddd3e68c71e9e398d8e40b71a2f39812
+        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
         with:
           path: |
             ~/.m2/repository


### PR DESCRIPTION
Related to #243 

Reverts https://github.com/jkubeio/jkube-integration-tests/pull/241 

The latest update of actions/cache seems to be causing issues in E2E test runs. Looks like some bug has been introduced (linked in the issue comment).

Reverting to the previous version of actions/cache, for now, to see if it actually fixes the issue.