### PR TITLE
chore (deps) : bump actions/cache to `69d9d449aced6a2ede0bc19182fadc3a0a42d2b0` revision (#243)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -53,7 +53,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
         with:
           path: |
             ~/.m2/repository
@@ -89,7 +89,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
         with:
           path: |
             ~/.m2/repository
@@ -165,7 +165,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
         with:
           path: |
             ~/.m2/repository
@@ -268,7 +268,7 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Cache configuration
-        uses: actions/cache@efacb0248bc628516687ca7c7e66dd076a46db1f
+        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
         with:
           path: |
             ~/.m2/repository


### PR DESCRIPTION
Fix #243 

Upgrade actions/cache to latest revision that contains fix related to zstd