### PR TITLE
test : Add test to verify OpenShift trace logging works

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/Quarkus.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/Quarkus.java
@@ -59,7 +59,7 @@ abstract class Quarkus implements JKubeCase, MavenCase {
   final Pod assertThatShouldApplyResources() throws Exception {
     final Pod pod = awaitPod(this).getKubernetesResource();
     assertPod(pod).apply(this)
-      .logContains("quarkus-rest 0.0.0-SNAPSHOT on JVM (powered by Quarkus ", 60)
+      .logContains(getApplication() + " 0.0.0-SNAPSHOT on JVM (powered by Quarkus ", 60)
       .logContains(".Final) started in", 10);
     awaitService(this, pod.getMetadata().getNamespace())
       .assertIsNodePort()

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusOcITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusOcITCase.java
@@ -50,7 +50,6 @@ class QuarkusOcITCase extends Quarkus implements OpenShiftCase {
   @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
   @DisplayName("oc:build, should create image")
   void ocBuild() throws Exception {
-    getOpenShiftClient().imageStreams().delete();
     // When
     final InvocationResult invocationResult = maven("oc:build");
     // Then

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusOcTraceEnabledITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/QuarkusOcTraceEnabledITCase.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.quarkus.rest;
+
+import io.fabric8.openshift.api.model.ImageStream;
+import org.apache.maven.shared.invoker.InvocationResult;
+import org.eclipse.jkube.integrationtests.OpenShiftCase;
+import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.util.Properties;
+
+import static org.eclipse.jkube.integrationtests.Locks.CLUSTER_RESOURCE_INTENSIVE;
+import static org.eclipse.jkube.integrationtests.Tags.OPEN_SHIFT;
+import static org.eclipse.jkube.integrationtests.Tags.OPEN_SHIFT_OSCI;
+import static org.eclipse.jkube.integrationtests.assertions.InvocationResultAssertion.assertInvocation;
+import static org.eclipse.jkube.integrationtests.assertions.JKubeAssertions.assertJKube;
+import static org.eclipse.jkube.integrationtests.assertions.KubernetesListAssertion.assertListResource;
+import static org.eclipse.jkube.integrationtests.assertions.YamlAssertion.yaml;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.text.StringContainsInOrder.stringContainsInOrder;
+import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
+
+@Tag(OPEN_SHIFT)
+@Tag(OPEN_SHIFT_OSCI)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class QuarkusOcTraceEnabledITCase extends Quarkus implements OpenShiftCase {
+
+  @Override
+  public String getProject() {
+    return "projects-to-be-tested/maven/quarkus/rest-trace-logging-enabled";
+  }
+
+  @Override
+  public String getApplication() {
+    return "quarkus-rest-trace-logging-enabled";
+  }
+
+  @Test
+  @Order(1)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
+  @DisplayName("oc:build, with org.slf4j.simpleLogger.defaultLogLevel=trace, should create image and print trace logs")
+  void ocBuild() throws Exception {
+    // Given
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+    // When
+    final InvocationResult invocationResult = maven("clean package oc:build",
+      properties("org.slf4j.simpleLogger.defaultLogLevel", "trace"), baos);
+    // Then
+    assertInvocation(invocationResult);
+    String ocBuildLog = baos.toString();
+    assertThat(ocBuildLog, containsString("[TRACE] -HTTP START-"));
+    assertThat(ocBuildLog, containsString("[TRACE] -HTTP END-"));
+    assertThat(ocBuildLog, containsString("[TRACE] -WS START-"));
+    assertThat(ocBuildLog, containsString("[TRACE] -WS END-"));
+    ImageStream is = getOpenShiftClient().imageStreams().withName(getApplication()).get();
+
+    assertThat(is.getStatus().getTags().iterator().next().getTag(), equalTo("latest"));
+    assertThat(getOpenShiftClient().imageStreams().withName(getApplication()).get(), notNullValue());
+  }
+
+  @Test
+  @Order(2)
+  @DisplayName("oc:resource, should create manifests")
+  void ocResource() throws Exception {
+    // When
+    final InvocationResult invocationResult = maven("oc:resource");
+    // Then
+    assertInvocation(invocationResult);
+    final File metaInfDirectory = new File(
+      String.format("../%s/target/classes/META-INF", getProject()));
+    assertThat(metaInfDirectory.exists(), equalTo(true));
+    assertListResource(new File(metaInfDirectory, "jkube/openshift.yml"));
+    assertThat(new File(metaInfDirectory, "jkube/openshift/quarkus-rest-trace-logging-enabled-deploymentconfig.yml"), yaml(not(anEmptyMap())));
+    assertThat(new File(metaInfDirectory, "jkube/openshift/quarkus-rest-trace-logging-enabled-service.yml"), yaml(not(anEmptyMap())));
+  }
+
+  @Test
+  @Order(3)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
+  @DisplayName("oc:apply, with org.slf4j.simpleLogger.defaultLogLevel=trace, should deploy pod and service and print trace logs")
+  void ocApply() throws Exception {
+    // Given
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    assertThat(getOpenShiftClient().imageStreams().withName(getApplication()).get(), notNullValue());
+    // When
+    final InvocationResult invocationResult = maven("oc:apply",
+      properties("org.slf4j.simpleLogger.defaultLogLevel", "trace")
+      , baos);
+    // Then
+    String ocApplyLog = baos.toString();
+    assertThat(ocApplyLog, containsString("[TRACE] -HTTP START-"));
+    assertThat(ocApplyLog, containsString("[TRACE] -HTTP END-"));
+    assertInvocation(invocationResult);
+    assertThatShouldApplyResources();
+  }
+
+  @Test
+  @Order(4)
+  @DisplayName("oc:log, with org.slf4j.simpleLogger.defaultLogLevel=trace, should retrieve log and print trace logs")
+  void ocLog() throws Exception {
+    // Given
+    Properties properties = new Properties();
+    properties.put("org.slf4j.simpleLogger.defaultLogLevel", "trace");
+    properties.put("jkube.log.follow", "false");
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    // When
+    final MavenInvocationResult invocationResult = maven("oc:log", properties, baos);
+    // Then
+    String ocLogGoalLog = baos.toString();
+    assertThat(ocLogGoalLog, containsString("[TRACE] -HTTP START-"));
+    assertThat(ocLogGoalLog, containsString("[TRACE] -HTTP END-"));
+    assertThat(ocLogGoalLog, containsString("[TRACE] -WS START-"));
+    assertThat(ocLogGoalLog, containsString("[TRACE] -WS END-"));
+    assertInvocation(invocationResult);
+    assertThat(invocationResult.getStdOut(),
+      stringContainsInOrder(String.format("INFO: %s 0.0.0-SNAPSHOT on JVM", getApplication()), " started in "));
+  }
+
+  @Test
+  @Order(5)
+  @ResourceLock(value = CLUSTER_RESOURCE_INTENSIVE, mode = READ_WRITE)
+  @DisplayName("oc:undeploy, with org.slf4j.simpleLogger.defaultLogLevel=trace, should delete all applied resources and print trace logs")
+  void ocUndeploy() throws Exception {
+    // Given
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    // When
+    final InvocationResult invocationResult = maven("oc:undeploy",
+      properties("org.slf4j.simpleLogger.defaultLogLevel", "trace"), baos);
+    // Then
+    String ocUndeployLog = baos.toString();
+    assertThat(ocUndeployLog, containsString("[TRACE] -HTTP START-"));
+    assertThat(ocUndeployLog, containsString("[TRACE] -HTTP END-"));
+    assertInvocation(invocationResult);
+    assertJKube(this)
+      .assertThatShouldDeleteAllAppliedResources();
+    cleanUpCluster();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,7 @@
       <id>quarkus</id>
       <modules>
         <module>projects-to-be-tested/maven/quarkus/rest</module>
+        <module>projects-to-be-tested/maven/quarkus/rest-trace-logging-enabled</module>
       </modules>
       <activation>
         <file>

--- a/projects-to-be-tested/maven/quarkus/rest-trace-logging-enabled/pom.xml
+++ b/projects-to-be-tested/maven/quarkus/rest-trace-logging-enabled/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2019 Red Hat, Inc.
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at:
+
+        https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+      Red Hat, Inc. - initial API and implementation
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jkube.integration-tests</groupId>
+    <artifactId>jkube-integration-tests-project</artifactId>
+    <version>${revision}</version>
+    <relativePath>../../../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>quarkus-rest-trace-logging-enabled</artifactId>
+  <name>${global.name} :: Quarkus :: Rest :: Trace Logging Enabled</name>
+  <description>
+    Quarkus REST JSON project
+  </description>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.quarkus.platform</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${quarkus.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-resteasy-jackson</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>io.quarkus.platform</groupId>
+        <artifactId>quarkus-maven-plugin</artifactId>
+        <version>${quarkus.version}</version>
+        <extensions>true</extensions>
+        <executions>
+          <execution>
+            <goals>
+              <goal>build</goal>
+              <goal>generate-code</goal>
+              <goal>generate-code-tests</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.eclipse.jkube</groupId>
+        <artifactId>openshift-maven-plugin</artifactId>
+        <configuration>
+            <enricher>
+              <config>
+                <jkube-service>
+                  <type>NodePort</type>
+                </jkube-service>
+              </config>
+            </enricher>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/projects-to-be-tested/maven/quarkus/rest-trace-logging-enabled/src/main/java/org/eclipse/jkube/integrationtests/quarkus/rest/CoolApplicationWithTraceEnabled.java
+++ b/projects-to-be-tested/maven/quarkus/rest-trace-logging-enabled/src/main/java/org/eclipse/jkube/integrationtests/quarkus/rest/CoolApplicationWithTraceEnabled.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.quarkus.rest;
+
+public class CoolApplicationWithTraceEnabled {
+
+  private final String applicationName;
+  private final String message;
+
+  public CoolApplicationWithTraceEnabled(String applicationName, String message) {
+    this.applicationName = applicationName;
+    this.message = message;
+  }
+
+  public String getApplicationName() {
+    return applicationName;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/projects-to-be-tested/maven/quarkus/rest-trace-logging-enabled/src/main/java/org/eclipse/jkube/integrationtests/quarkus/rest/CoolApplicationWithTraceEnabledResource.java
+++ b/projects-to-be-tested/maven/quarkus/rest-trace-logging-enabled/src/main/java/org/eclipse/jkube/integrationtests/quarkus/rest/CoolApplicationWithTraceEnabledResource.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.quarkus.rest;
+
+import jakarta.inject.Inject;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+@Path("/")
+public class CoolApplicationWithTraceEnabledResource {
+
+  private CoolApplicationWithTraceEnabledService coolApplicationService;
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response get() {
+    return Response.ok(coolApplicationService.getCoolApplication()).build();
+  }
+
+  @Inject
+  public void setCoolApplicationService(CoolApplicationWithTraceEnabledService coolApplicationService) {
+    this.coolApplicationService = coolApplicationService;
+  }
+}

--- a/projects-to-be-tested/maven/quarkus/rest-trace-logging-enabled/src/main/java/org/eclipse/jkube/integrationtests/quarkus/rest/CoolApplicationWithTraceEnabledService.java
+++ b/projects-to-be-tested/maven/quarkus/rest-trace-logging-enabled/src/main/java/org/eclipse/jkube/integrationtests/quarkus/rest/CoolApplicationWithTraceEnabledService.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.integrationtests.quarkus.rest;
+
+import jakarta.inject.Singleton;
+
+@Singleton
+public class CoolApplicationWithTraceEnabledService {
+
+  CoolApplicationWithTraceEnabled getCoolApplication() {
+    return new CoolApplicationWithTraceEnabled("JKube", "Subatomic JKube really whips the llama's ass!");
+  }
+}


### PR DESCRIPTION
Related to https://github.com/eclipse/jkube/issues/2211

+ Add QuarkusOcTraceEnabledITCase to test suite which verifies
      openshift maven plugin goals with `org.slf4j.simpleLogger.defaultLogLevel`
      property set to trace
+ Add new test project `maven/quarkus/rest-trace-logging-enabled` for
      testing abovementioned integration test
