### PR TITLE
test : Remove ENTRYPOINT assertion from CompleteOcDockerITCase

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteOcDockerITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteOcDockerITCase.java
@@ -70,8 +70,7 @@ class CompleteOcDockerITCase extends Complete implements OpenShiftCase {
       "COPY /dependencies/deployments /deployments/",
       "COPY /spring-boot-loader/deployments /deployments/",
       "COPY /application/deployments /deployments",
-      "WORKDIR /deployment",
-      "ENTRYPOINT [\"java\",\"org.springframework.boot.loader.JarLauncher\"]");
+      "WORKDIR /deployment");
   }
 
   @Test


### PR DESCRIPTION
This was removed in https://github.com/eclipse/jkube/pull/2437 


Update CompleteOcDockerITCase with respect to this change.