### PR TITLE
fix(build-jkube): allow downloads from githubusercontent.com for Gradle download

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -47,6 +47,7 @@ jobs:
             repo1.maven.org:443
             repository.jboss.org:443
             services.gradle.org:443
+            objects.githubusercontent.com:443
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Setup Java 11


### PR DESCRIPTION
Resolves an issue where the github action build failed during the `Build JKube` step due to the inability to download Gradle. This fix enables downloads from githubusercontent.com, resolving the download issue.

```
[info] Downloading Gradle 7.6.2...
Error: [ERROR] Internal error: java.lang.IllegalStateException: Couldn't download Gradle 7.6.2: Connection refused (Connection refused) -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: java.lang.IllegalStateException: Couldn't download Gradle 7.6.2
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:121)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:9[63](https://github.com/jkubeio/jkube-integration-tests/actions/runs/6826073585/job/18587132317?pr=354#step:8:64))
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.lang.IllegalStateException: Couldn't download Gradle 7.6.2
    at com.marcnuri.plugins.gradle.api.GradleApi.download (GradleApi.java:61)
    at com.marcnuri.plugins.gradle.api.GradleApi.call (GradleApi.java:47)
    at com.marcnuri.plugins.gradle.api.GradleApiExtension.afterProjectsRead (GradleApiExtension.java:41)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:254)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: java.net.ConnectException: Connection refused (Connection refused)
    at java.net.PlainSocketImpl.socketConnect (Native Method)
    at java.net.AbstractPlainSocketImpl.doConnect (AbstractPlainSocketImpl.java:412)
    at java.net.AbstractPlainSocketImpl.connectToAddress (AbstractPlainSocketImpl.java:255)
    at java.net.AbstractPlainSocketImpl.connect (AbstractPlainSocketImpl.java:237)
    at java.net.SocksSocketImpl.connect (SocksSocketImpl.java:392)
    at java.net.Socket.connect (Socket.java:609)
    at sun.security.ssl.SSLSocketImpl.connect (SSLSocketImpl.java:305)
    at sun.security.ssl.BaseSSLSocketImpl.connect (BaseSSLSocketImpl.java:173)
    at sun.net.NetworkClient.doConnect (NetworkClient.java:182)
    at sun.net.www.http.HttpClient.openServer (HttpClient.java:509)
    at sun.net.www.http.HttpClient.openServer (HttpClient.java:604)
    at sun.net.www.protocol.https.HttpsClient.<init> (HttpsClient.java:266)
    at sun.net.www.protocol.https.HttpsClient.New (HttpsClient.java:373)
    at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.getNewHttpClient (AbstractDelegateHttpsURLConnection.java:207)
    at sun.net.www.protocol.http.HttpURLConnection.plainConnect0 (HttpURLConnection.java:1187)
    at sun.net.www.protocol.http.HttpURLConnection.plainConnect (HttpURLConnection.java:1081)
    at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect (AbstractDelegateHttpsURLConnection.java:193)
    at sun.net.www.protocol.http.HttpURLConnection.followRedirect0 (HttpURLConnection.java:2815)
    at sun.net.www.protocol.http.HttpURLConnection.followRedirect (HttpURLConnection.java:2727)
    at sun.net.www.protocol.http.HttpURLConnection.getInputStream0 (HttpURLConnection.java:1854)
    at sun.net.www.protocol.http.HttpURLConnection.getInputStream (HttpURLConnection.java:1520)
    at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream (HttpsURLConnectionImpl.java:250)
    at java.net.URL.openStream (URL.java:1165)
    at com.marcnuri.plugins.gradle.api.GradleApi.download (GradleApi.java:57)
    at com.marcnuri.plugins.gradle.api.GradleApi.call (GradleApi.java:47)
    at com.marcnuri.plugins.gradle.api.GradleApiExtension.afterProjectsRead (GradleApiExtension.java:41)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:254)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:193)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:106)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:963)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:296)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:199)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0 (Native Method)
    at jdk.internal.reflect.NativeMethodAccessorImpl.invoke (NativeMethodAccessorImpl.java:62)
    at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke (DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke (Method.java:566)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/InternalErrorException
Error: Process completed with exit code 1.
```