### PR TITLE
fix(webapp): fix Jetty 12 watch test failures

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyK8sWatch.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyK8sWatch.java
@@ -90,7 +90,10 @@ abstract class JettyK8sWatch implements JKubeCase, MavenCase {
   void waitUntilApplicationRestartsInsidePod() throws ExecutionException, InterruptedException, TimeoutException {
     PodResource podResource = getKubernetesClient().pods().resource(originalPod);
     await(podResource::getLog)
-      .apply(l -> l.contains("Scanner-0: Started oeje10w.WebAppContext"))
+      .apply(l -> l.contains("Stopped oeje10w.WebAppContext"))
+      .get(10, TimeUnit.SECONDS);
+    await(podResource::getLog)
+      .apply(l -> l.indexOf("Started oeje10w.WebAppContext", l.indexOf("Stopped oeje10w.WebAppContext")) > 0)
       .get(10, TimeUnit.SECONDS);
   }
 }

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyK8sWatchBothITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/webapp/jetty/JettyK8sWatchBothITCase.java
@@ -58,7 +58,7 @@ class JettyK8sWatchBothITCase extends JettyK8sWatch {
       assertInvocation(maven("package"));
       await(baos::toString).apply(log -> log.contains("Updating Deployment")).get(10, TimeUnit.SECONDS);
       // Then
-      getKubernetesClient().pods().resource(originalPod).waitUntilCondition(Objects::isNull, 30, TimeUnit.SECONDS);
+      getKubernetesClient().pods().resource(originalPod).waitUntilCondition(Objects::isNull, 120, TimeUnit.SECONDS);
       assertThat(baos.toString(StandardCharsets.UTF_8), stringContainsInOrder(
         "Waiting ...",
         // Build

--- a/projects-to-be-tested/maven/webapp/jetty-watch-copy/src/main/jkube/deployment.yml
+++ b/projects-to-be-tested/maven/webapp/jetty-watch-copy/src/main/jkube/deployment.yml
@@ -1,3 +1,17 @@
+#
+# Copyright (c) 2019 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at:
+#
+#     https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
+
 spec:
   template:
     spec:

--- a/projects-to-be-tested/maven/webapp/jetty-watch-copy/src/main/jkube/deployment.yml
+++ b/projects-to-be-tested/maven/webapp/jetty-watch-copy/src/main/jkube/deployment.yml
@@ -1,0 +1,7 @@
+spec:
+  template:
+    spec:
+      containers:
+        - env:
+            - name: JAVA_TOOL_OPTIONS
+              value: "-Djetty.deploy.scanInterval=1"


### PR DESCRIPTION
## Summary

Fixes Jetty 12 watch test failures caused by the default image change in eclipse-jkube/jkube#3914.

### Changes

- **Watch-copy scanner fix**: The `jkube-jetty12` image defaults to `scanInterval=0` (hot-deploy disabled). Added a JKube resource fragment that injects `JAVA_TOOL_OPTIONS=-Djetty.deploy.scanInterval=1` into the container, enabling the deployment scanner to detect file changes.

- **Watch-copy restart detection**: Updated `waitUntilApplicationRestartsInsidePod()` to use two-step verification matching actual Jetty 12 log output:
  - Wait for `"Stopped oeje10w.WebAppContext"` (scanner-triggered stop)
  - Wait for `"Started oeje10w.WebAppContext"` after the stop (restart complete)

- **Watch-both timeout**: Increased pod deletion timeout from 30s to 120s. Jetty 12 (JDK 21) takes longer to start, which delays deployment rollout before the old pod is terminated.

## Test plan

- [x] Verified locally on Minikube (K8s v1.36, ARM64): all 3 Jetty 12 watch tests pass
  - `JettyK8sWatchCopyITCase` — 28s
  - `JettyK8sWatchBothITCase` — 66s
  - `JettyK8sWatchNoneITCase` — 10s

Relates to: eclipse-jkube/jkube#3915