### PR TITLE
fix(buildpacks): update assertions for Paketo builder-jammy-base image

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/buildpacks/BuildPacksBuildStrategyK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/buildpacks/BuildPacksBuildStrategyK8sITCase.java
@@ -110,7 +110,7 @@ class BuildPacksBuildStrategyK8sITCase implements JKubeCase, MavenCase {
       "[INFO] BUILD SUCCESS"
     ));
     Map<String, String> imageLabels = getLabels("integration-tests/buildpacks-simple:latest");
-    assertThat(imageLabels, hasKey("io.buildpacks.stack.id"));
+    assertThat(imageLabels, hasEntry("io.buildpacks.stack.id", "io.buildpacks.stacks.jammy"));
     assertThat(imageLabels, hasEntry("io.buildpacks.project.metadata", "{}"));
     assertThat(imageLabels, hasKey("io.buildpacks.build.metadata"));
     assertThat(imageLabels, hasKey("io.buildpacks.lifecycle.metadata"));

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/buildpacks/BuildPacksBuildStrategyK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/buildpacks/BuildPacksBuildStrategyK8sITCase.java
@@ -102,7 +102,7 @@ class BuildPacksBuildStrategyK8sITCase implements JKubeCase, MavenCase {
     assertThat(invocationResult.getStdOut(), stringContainsInOrder(
       "Delegating container image building process to BuildPacks",
       "Using pack",
-      "base: Pulling from paketobuildpacks/builder",
+      "Pulling from paketobuildpacks/builder",
       "===> ANALYZING",
       "===> DETECTING",
       "===> EXPORTING",
@@ -110,7 +110,7 @@ class BuildPacksBuildStrategyK8sITCase implements JKubeCase, MavenCase {
       "[INFO] BUILD SUCCESS"
     ));
     Map<String, String> imageLabels = getLabels("integration-tests/buildpacks-simple:latest");
-    assertThat(imageLabels, hasEntry("io.buildpacks.stack.id", "io.buildpacks.stacks.bionic"));
+    assertThat(imageLabels, hasKey("io.buildpacks.stack.id"));
     assertThat(imageLabels, hasEntry("io.buildpacks.project.metadata", "{}"));
     assertThat(imageLabels, hasKey("io.buildpacks.build.metadata"));
     assertThat(imageLabels, hasKey("io.buildpacks.lifecycle.metadata"));


### PR DESCRIPTION
## Summary

The Paketo Buildpacks project renamed their builder image from `paketobuildpacks/builder:base` (Ubuntu Bionic) to `paketobuildpacks/builder-jammy-base:latest` (Ubuntu Jammy). This broke the `BuildPacksBuildStrategyK8sITCase.k8sBuild` assertion.

### Changes

- Use `"Pulling from paketobuildpacks/builder"` substring to match both old (`base: Pulling from paketobuildpacks/builder`) and new (`latest: Pulling from paketobuildpacks/builder-jammy-base`) image names
- Update stack ID assertion from `io.buildpacks.stacks.bionic` to `io.buildpacks.stacks.jammy`