### PR TITLE
chore(deps): modernize sample base images and framework versions

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteDockerITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/complete/CompleteDockerITCase.java
@@ -84,7 +84,7 @@ class CompleteDockerITCase extends Complete {
     assertThat(new File(dockerDirectory, "tmp/docker-build.tar.gz").exists(), equalTo(true));
     final String dockerFileContent = String.join("\n",
       Files.readAllLines(new File(dockerDirectory, "build/Dockerfile").toPath()));
-    assertThat(dockerFileContent, containsString("FROM adoptopenjdk/openjdk11:alpine-slim"));
+    assertThat(dockerFileContent, containsString("FROM eclipse-temurin:11-jre-alpine"));
     assertThat(dockerFileContent, containsString("ENV JAVA_APP_DIR=/deployments"));
     assertThat(dockerFileContent, containsString("LABEL some.label=\"The value\""));
     assertThat(dockerFileContent, containsString("EXPOSE 8082 8778 9779"));

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
     <com.fasterxml.jackson.dataformat.yaml.version>2.15.2</com.fasterxml.jackson.dataformat.yaml.version>
     <fabric8.kubernetes-client.version>7.0.1</fabric8.kubernetes-client.version>
     <guava.version>32.1.2-jre</guava.version> <!-- Required by Gradle Test Toolkit (testkit) -->
-    <gradle.version>8.7</gradle.version>
+    <gradle.version>8.14.5</gradle.version>
     <gradle-api-maven-plugin-version>0.0.3</gradle-api-maven-plugin-version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
@@ -48,17 +48,17 @@
     <javax.servlet-api.version>4.0.1</javax.servlet-api.version>
     <javax.servlet.jsp-api.version>2.3.3</javax.servlet.jsp-api.version>
     <!-- JKube version also needs to be updated in projects-to-be-tested/maven/buildpacks/simple/pom.xml -->
-    <jkube.version>1.18-SNAPSHOT</jkube.version>
+    <jkube.version>1.20-SNAPSHOT</jkube.version>
     <junit.version>5.11.0</junit.version>
-    <karaf.version>4.4.6</karaf.version>
+    <karaf.version>4.4.11</karaf.version>
     <license-maven-plugin.version>4.2</license-maven-plugin.version>
-    <openliberty.version>23.0.0.9</openliberty.version>
+    <openliberty.version>25.0.0.12</openliberty.version>
     <openliberty.plugin.version>3.0.1</openliberty.plugin.version>
-    <quarkus.version>3.2.3.Final</quarkus.version>
+    <quarkus.version>3.2.12.Final</quarkus.version>
     <slf4j.version>2.0.7</slf4j.version>
-    <spring-boot.version>2.7.11</spring-boot.version>
-    <spring-boot.fat-jar.version>2.3.9.RELEASE</spring-boot.fat-jar.version>
-    <vertx.version>4.4.5</vertx.version>
+    <spring-boot.version>2.7.18</spring-boot.version>
+    <spring-boot.fat-jar.version>2.3.12.RELEASE</spring-boot.fat-jar.version>
+    <vertx.version>4.5.28</vertx.version>
     <vertx.plugin.version>1.0.28</vertx.plugin.version>
     <wildfly.jar.plugin.version>11.0.2.Final</wildfly.jar.plugin.version>
     <version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>2.0.2.Final</version.org.jboss.spec.javax.ws.jboss-jaxrs-api_2.1_spec>

--- a/projects-to-be-tested/gradle/dsl/build.gradle
+++ b/projects-to-be-tested/gradle/dsl/build.gradle
@@ -26,7 +26,7 @@ jar {
 def imageDef = {
   name = "gradle/${project.name}"
   build {
-    from = 'openjdk:11.0.16-jre-slim'
+    from = 'eclipse-temurin:11-jre'
     env {
       GREETING = 'May the 4th be with you'
     }

--- a/projects-to-be-tested/maven/buildpacks/simple/pom.xml
+++ b/projects-to-be-tested/maven/buildpacks/simple/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <!-- Since there is no parent pom, we have to manually define JKube version here -->
-    <jkube.version>1.17-SNAPSHOT</jkube.version>
+    <jkube.version>1.20-SNAPSHOT</jkube.version>
     <jkube.build.strategy>buildpacks</jkube.build.strategy>
     <jkube.enricher.jkube-service.type>NodePort</jkube.enricher.jkube-service.type>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/projects-to-be-tested/maven/dockerfile/context-dir-and-custom-assembly/src/main/docker-context-dir/Dockerfile
+++ b/projects-to-be-tested/maven/dockerfile/context-dir-and-custom-assembly/src/main/docker-context-dir/Dockerfile
@@ -12,7 +12,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM openjdk:11.0.16-jre-slim
+FROM eclipse-temurin:11-jre
 ADD input-files/subdirectory-in-context /deployments/subdirectory
 COPY input-files/file-in-context.txt /deployments/file-in-context.txt
 ENTRYPOINT [ "echo READY PLAYER 1 && sleep 3600" ]

--- a/projects-to-be-tested/maven/dockerfile/context-dir-and-docker-file/src/main/docker-context-dir/subdirectory-in-context/DockerfileSpecial
+++ b/projects-to-be-tested/maven/dockerfile/context-dir-and-docker-file/src/main/docker-context-dir/subdirectory-in-context/DockerfileSpecial
@@ -12,7 +12,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM openjdk:11.0.16-jre-slim
+FROM eclipse-temurin:11-jre
 ADD maven/subdirectory-in-context /deployments/subdirectory
 COPY maven/file-in-context.txt /deployments/file-in-context.txt
 ENTRYPOINT [ "echo READY PLAYER 1 && sleep 3600" ]

--- a/projects-to-be-tested/maven/dockerfile/context-dir/src/main/docker-context-dir/Dockerfile
+++ b/projects-to-be-tested/maven/dockerfile/context-dir/src/main/docker-context-dir/Dockerfile
@@ -12,7 +12,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM openjdk:11.0.16-jre-slim
+FROM eclipse-temurin:11-jre
 ADD maven/subdirectory-in-context /deployments/subdirectory
 COPY maven/file-in-context.txt /deployments/file-in-context.txt
 ENTRYPOINT [ "echo READY PLAYER 1 && sleep 3600" ]

--- a/projects-to-be-tested/maven/dockerfile/docker-file/src/main/docker/subdirectory/Dockerfile
+++ b/projects-to-be-tested/maven/dockerfile/docker-file/src/main/docker/subdirectory/Dockerfile
@@ -12,6 +12,6 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM openjdk:11.0.16-jre-slim
+FROM eclipse-temurin:11-jre
 COPY maven/file-in-context.txt /deployments/file-in-context.txt
 ENTRYPOINT [ "echo READY PLAYER 1 && sleep 3600" ]

--- a/projects-to-be-tested/maven/dockerfile/simple/Dockerfile
+++ b/projects-to-be-tested/maven/dockerfile/simple/Dockerfile
@@ -12,7 +12,7 @@
 #   Red Hat, Inc. - initial API and implementation
 #
 
-FROM openjdk:11.0.16-jre-slim
+FROM eclipse-temurin:11-jre
 COPY maven/target/*.jar /deployments/app.jar
 COPY maven/static-dir-in-project-root/my-file.txt /deployments/my-file.txt
 EXPOSE 8080

--- a/projects-to-be-tested/maven/spring/complete/pom.xml
+++ b/projects-to-be-tested/maven/spring/complete/pom.xml
@@ -73,7 +73,7 @@
         <jkube.environment>docker</jkube.environment>
         <jkube.targetDir>${project.build.outputDirectory}/META-INF/jkube-docker</jkube.targetDir>
         <jkube.kubernetesManifest>${project.build.outputDirectory}/META-INF/jkube-docker/kubernetes.yml</jkube.kubernetesManifest>
-        <jkube.generator.from>adoptopenjdk/openjdk11:jdk-11.0.6_10-alpine-slim</jkube.generator.from>
+        <jkube.generator.from>eclipse-temurin:11-jdk-alpine</jkube.generator.from>
         <jkube.enricher.jkube-controller.name>spring-boot-complete-docker</jkube.enricher.jkube-controller.name>
         <jkube.enricher.jkube-project-label.app>spring-boot-complete-docker</jkube.enricher.jkube-project-label.app>
         <jkube.enricher.jkube-service.name>spring-boot-complete-docker</jkube.enricher.jkube-service.name>
@@ -91,7 +91,7 @@
                 <build>
                   <cleanup>remove</cleanup>
                   <compression>gzip</compression>
-                  <from>adoptopenjdk/openjdk11:alpine-slim</from>
+                  <from>eclipse-temurin:11-jre-alpine</from>
                   <tags>
                     <tag>latest</tag>
                     <tag>1337</tag>


### PR DESCRIPTION
Modernizes the container base images and framework/tool versions used by the sample projects. Fixes #407.

## Part A — Base images
Replaces deprecated `adoptopenjdk/*` (archived 2021) and Docker Hub `openjdk:*` (deprecated) base images with the maintained `eclipse-temurin` successor, keeping the alpine/glibc variant equivalent:
- 5 `dockerfile` samples + the Gradle DSL sample: `openjdk:11.0.16-jre-slim` → `eclipse-temurin:11-jre`
- `spring/complete`: `jkube.generator.from` → `eclipse-temurin:11-jdk-alpine`; image `<from>` → `eclipse-temurin:11-jre-alpine` (the sample only runs `java -jar`, so the runtime image uses a JRE)
- Updated the `CompleteDockerITCase` assertion to match the new base image

## Part B — Framework / tool versions (root `pom.xml`)
- spring-boot `2.7.11` → `2.7.18` (final 2.7.x)
- spring-boot fat-jar `2.3.9.RELEASE` → `2.3.12.RELEASE` (final 2.3.x)
- quarkus `3.2.3.Final` → `3.2.12.Final` (latest 3.2 LTS)
- vertx `4.4.5` → `4.5.28` (latest 4.5.x)
- karaf `4.4.6` → `4.4.11` (latest 4.4.x)
- openliberty `23.0.0.9` → `25.0.0.12`
- gradle `8.7` → `8.14.5` (latest 8.x)

The `wildfly-jar` plugin is already at the latest 11.x (`11.0.2.Final`); Camel `2.25.4` is left as-is (Camel 2 is EOL — a 3/4 migration is tracked separately).

## JKube version under test
- `jkube.version` `1.18-SNAPSHOT` → `1.20-SNAPSHOT` (root `pom.xml` and `buildpacks/simple/pom.xml`), tracking the next JKube release.

## Verification
- `mvn -N license:check` passes
- All sample projects build (`-DskipTests install`)
- `Kubernetes` suites run green locally (minikube) for every changed area: `dockerfile` (8/8), spring `Complete` (13/13, incl. the base-image assertion), OpenLiberty, Gradle DSL, WildFly-jar, buildpacks, Vert.x, Karaf (5/5), Quarkus (5/5)