### PR TITLE
chore(ci): apply E2E pipeline improvements (N1-N5)

### DIFF
--- a/.github/workflows/build-jkube.yml
+++ b/.github/workflows/build-jkube.yml
@@ -62,6 +62,7 @@ jobs:
         id: jkube-sha
         run: |
           sha=$(git ls-remote "$JKUBE_REPOSITORY" "refs/heads/$JKUBE_REVISION" | cut -f1)
+          [ -n "$sha" ] || { echo "::error::could not resolve $JKUBE_REVISION SHA"; exit 1; }
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
       # Third-party dependencies, stable across runs (invalidated when poms change).
       # Restored first so the SHA-keyed JKube cache below wins for org/eclipse/jkube.

--- a/.github/workflows/build-jkube.yml
+++ b/.github/workflows/build-jkube.yml
@@ -16,11 +16,10 @@ name: Build Eclipse JKube master/main
 
 on:
   workflow_call:
-    inputs:
-      run-id:
-        description: The run id of the workflow that triggered this workflow (to be used for caching)
-        required: true
-        type: string
+    outputs:
+      jkube-sha:
+        description: The resolved JKube master commit SHA, used as the cross-run cache key.
+        value: ${{ jobs.build-jkube.outputs.jkube-sha }}
 
 env:
   JKUBE_REPOSITORY: https://github.com/eclipse-jkube/jkube.git
@@ -34,6 +33,8 @@ jobs:
   build-jkube:
     name: Build JKube
     runs-on: ubuntu-latest
+    outputs:
+      jkube-sha: ${{ steps.jkube-sha.outputs.sha }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc
@@ -57,20 +58,34 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Cache configuration
+      - name: Resolve JKube master commit SHA
+        id: jkube-sha
+        run: |
+          sha=$(git ls-remote "$JKUBE_REPOSITORY" "refs/heads/$JKUBE_REVISION" | cut -f1)
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+      # Third-party dependencies, stable across runs (invalidated when poms change).
+      # Restored first so the SHA-keyed JKube cache below wins for org/eclipse/jkube.
+      - name: Cache third-party Maven dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: m2-
+      # JKube build, invalidated only when master moves.
+      - name: Cache JKube build
+        id: jkube-cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
-            ~/.m2/repository
             ./jkube
-          key: cache-it-${{ inputs.run-id }}
-      - name: Checkout JKube Repository
+            ~/.m2/repository/org/eclipse/jkube
+          key: jkube-${{ steps.jkube-sha.outputs.sha }}
+      - name: Checkout and Install JKube
+        if: steps.jkube-cache.outputs.cache-hit != 'true'
         run: |
           rm -rf jkube \
-          && git clone "$JKUBE_REPOSITORY" --branch "$JKUBE_REVISION" jkube
-      - name: Install JKube
-        run: |
-          mvn -B -f "jkube/pom.xml" -DskipTests clean install
+          && git clone "$JKUBE_REPOSITORY" --branch "$JKUBE_REVISION" jkube \
+          && mvn -B -f "jkube/pom.xml" -DskipTests clean install
       - name: Install Integration Tests (Downloads dependencies)
         run: |
           ./mvnw -B -DskipTests clean install \

--- a/.github/workflows/e2e-crc-okd-tests.yml
+++ b/.github/workflows/e2e-crc-okd-tests.yml
@@ -31,8 +31,6 @@ jobs:
   build-jkube:
     name: Build JKube
     uses: ./.github/workflows/build-jkube.yml
-    with:
-      run-id: ${{ github.run_id }}
 
   openshift-kubernetes-distribution:
     name: CRC ${{ matrix.crc }} / OKD ${{ matrix.okd }} / ${{ matrix.suite }}
@@ -56,13 +54,21 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Cache configuration
+      # Restore the same caches populated by the build-jkube job (m2 first so the
+      # SHA-keyed JKube cache wins for org/eclipse/jkube).
+      - name: Restore third-party Maven dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: m2-
+      - name: Restore JKube build
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
-            ~/.m2/repository
             ./jkube
-          key: cache-it-${{ github.run_id }}
+            ~/.m2/repository/org/eclipse/jkube
+          key: jkube-${{ needs.build-jkube.outputs.jkube-sha }}
       - name: Install required virtualization software
         run: |
           sudo apt-get update

--- a/.github/workflows/e2e-crc-okd-tests.yml
+++ b/.github/workflows/e2e-crc-okd-tests.yml
@@ -57,13 +57,13 @@ jobs:
       # Restore the same caches populated by the build-jkube job (m2 first so the
       # SHA-keyed JKube cache wins for org/eclipse/jkube).
       - name: Restore third-party Maven dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ~/.m2/repository
           key: m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: m2-
       - name: Restore JKube build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ./jkube

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -27,7 +27,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Include the event name so a push to main does not cancel the in-flight
+  # nightly schedule run (both resolve github.ref to refs/heads/main).
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 jobs:
@@ -56,13 +58,13 @@ jobs:
       # Restore the same caches populated by the build-jkube job (m2 first so the
       # SHA-keyed JKube cache wins for org/eclipse/jkube).
       - name: Restore third-party Maven dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ~/.m2/repository
           key: m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: m2-
       - name: Restore JKube build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ./jkube
@@ -176,13 +178,13 @@ jobs:
       # Restore the same caches populated by the build-jkube job (m2 first so the
       # SHA-keyed JKube cache wins for org/eclipse/jkube).
       - name: Restore third-party Maven dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ~/.m2/repository
           key: m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: m2-
       - name: Restore JKube build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ./jkube

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -21,16 +21,19 @@ on:
   pull_request:
   schedule:
     - cron: '0 1 * * *' # Every day at 1
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-jkube:
     name: Build JKube
     uses: ./.github/workflows/build-jkube.yml
-    with:
-      run-id: ${{ github.run_id }}
 
   minikube:
     name: K8S
@@ -40,7 +43,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.32.4,v1.31.8,v1.30.12]
+        kubernetes: [v1.36.2, v1.35.6, v1.34.9, v1.30.14]
         suite: ['quarkus','quarkus-native','springboot','webapp','other','dockerfile']
     steps:
       - name: Checkout
@@ -50,17 +53,25 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Cache configuration
+      # Restore the same caches populated by the build-jkube job (m2 first so the
+      # SHA-keyed JKube cache wins for org/eclipse/jkube).
+      - name: Restore third-party Maven dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: m2-
+      - name: Restore JKube build
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
-            ~/.m2/repository
             ./jkube
-          key: cache-it-${{ github.run_id }}
+            ~/.m2/repository/org/eclipse/jkube
+          key: jkube-${{ needs.build-jkube.outputs.jkube-sha }}
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@96202dee4ae1c2f46a62fe197273aaf22b83f42d
+        uses: manusa/actions-setup-minikube@b65276017fdec6f1e6498129fb740e34e260dc55
         with:
-          minikube version: v1.35.0
+          minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: --force
@@ -103,88 +114,11 @@ jobs:
             us-east4-docker.pkg.dev:443
       - name: Install and Run Integration Tests
         run: |
-          JKUBE_VERSION=$(./mvnw -q -f 'jkube/pom.xml' -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
-          && ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION"
-      - name: Save reports as artifact
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
-        with:
-          name: Test reports (Minikube ${{ matrix.kubernetes }}-${{ matrix.suite }})
-          path: ./it/target/jkube-test-report.txt
-
-  minikube-unsupported:
-    name: K8S (Unsupported)
-    needs: build-jkube
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        kubernetes: [v1.29.14,v1.25.16]
-        suite: ['quarkus','quarkus-native','springboot','webapp','other','dockerfile']
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - name: Setup Java 11
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Cache configuration
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
-        with:
-          path: |
-            ~/.m2/repository
-            ./jkube
-          key: cache-it-${{ github.run_id }}
-      - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@96202dee4ae1c2f46a62fe197273aaf22b83f42d
-        with:
-          minikube version: v1.35.0
-          kubernetes version: ${{ matrix.kubernetes }}
-          github token: ${{ secrets.GITHUB_TOKEN }}
-          start args: --force
-      - name: Harden Runner
-        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc
-        with:
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            auth.docker.io:443
-            azure.archive.ubuntu.com:80
-            cdn03.quay.io:443
-            downloads.gradle.org:443
-            gcr.io:443
-            github.com:443
-            jcenter.bintray.com:443
-            k8s.gcr.io:443
-            maven.repository.redhat.com:443
-            md-hdd-51w5snc21ccf.z49.blob.storage.azure.net:443
-            md-hdd-bfh3mwcdlxsh.z21.blob.storage.azure.net:443
-            md-hdd-dxgvrxd2cnjf.z22.blob.storage.azure.net:443
-            objects.githubusercontent.com:443
-            packages.microsoft.com:443
-            plugins-artifacts.gradle.org:443
-            plugins.gradle.org:443
-            ppa.launchpadcontent.net:443
-            ppa.launchpad.net:80
-            production.cloudflare.docker.com:443
-            quay.io:443
-            services.gradle.org:443
-            registry-1.docker.io:443
-            registry.access.redhat.com:443
-            registry.k8s.io:443
-            repo1.maven.org:443
-            repo.maven.apache.org:443
-            repository.jboss.org:443
-            storage.googleapis.com:443
-            us-south1-docker.pkg.dev:443
-            us-west2-docker.pkg.dev:443
-            us-east4-docker.pkg.dev:443
-      - name: Install and Run Integration Tests
-        run: |
-          JKUBE_VERSION=$(./mvnw -q -f 'jkube/pom.xml' -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \
-          && ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION"
+          JKUBE_VERSION=$(./mvnw -q -f 'jkube/pom.xml' -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
+          s=$(date +%s)
+          ./mvnw -B -PKubernetes,${{ matrix.suite }} clean verify -Djkube.version="$JKUBE_VERSION" && rc=0 || rc=$?
+          echo "| ${{ matrix.kubernetes }} | ${{ matrix.suite }} | $(( $(date +%s) - s ))s | $([ $rc = 0 ] && echo ':heavy_check_mark:' || echo ':x:') |" >> "$GITHUB_STEP_SUMMARY"
+          exit $rc
       - name: Save reports as artifact
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -239,13 +173,21 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Cache configuration
+      # Restore the same caches populated by the build-jkube job (m2 first so the
+      # SHA-keyed JKube cache wins for org/eclipse/jkube).
+      - name: Restore third-party Maven dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: m2-
+      - name: Restore JKube build
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
-            ~/.m2/repository
             ./jkube
-          key: cache-it-${{ github.run_id }}
+            ~/.m2/repository/org/eclipse/jkube
+          key: jkube-${{ needs.build-jkube.outputs.jkube-sha }}
       - name: Check Docker Status
         run: systemctl status docker.service
       - name: Setup OpenShift

--- a/.github/workflows/openshift-osci.yml.wip
+++ b/.github/workflows/openshift-osci.yml.wip
@@ -42,13 +42,13 @@ jobs:
       # Restore the same caches populated by the build-jkube job (m2 first so the
       # SHA-keyed JKube cache wins for org/eclipse/jkube).
       - name: Restore third-party Maven dependencies
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ~/.m2/repository
           key: m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: m2-
       - name: Restore JKube build
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
             ./jkube

--- a/.github/workflows/openshift-osci.yml.wip
+++ b/.github/workflows/openshift-osci.yml.wip
@@ -26,8 +26,6 @@ jobs:
   build-jkube:
     name: Build JKube
     uses: ./.github/workflows/build-jkube.yml
-    with:
-      run-id: ${{ github.run_id }}
 
   openshift-osci:
     name: OpenShift OSCI
@@ -41,13 +39,21 @@ jobs:
         with:
           java-version: '11'
           distribution: 'temurin'
-      - name: Cache configuration
+      # Restore the same caches populated by the build-jkube job (m2 first so the
+      # SHA-keyed JKube cache wins for org/eclipse/jkube).
+      - name: Restore third-party Maven dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.m2/repository
+          key: m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: m2-
+      - name: Restore JKube build
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: |
-            ~/.m2/repository
             ./jkube
-          key: cache-it-${{ github.run_id }}
+            ~/.m2/repository/org/eclipse/jkube
+          key: jkube-${{ needs.build-jkube.outputs.jkube-sha }}
       - name: Install and Run Integration Tests
         run: |
           JKUBE_VERSION=$(./mvnw -q -f 'jkube/pom.xml' -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec) \

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes: [v1.32.11,v1.34.3]
+        kubernetes: [v1.36.2, v1.34.9]
         suite: ['quarkus','quarkus-native','springboot','webapp','other','dockerfile']
     steps:
       - name: Checkout
@@ -94,9 +94,9 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
       - name: Setup Minikube-Kubernetes
-        uses: manusa/actions-setup-minikube@96202dee4ae1c2f46a62fe197273aaf22b83f42d
+        uses: manusa/actions-setup-minikube@b65276017fdec6f1e6498129fb740e34e260dc55
         with:
-          minikube version: v1.38.0
+          minikube version: v1.38.1
           kubernetes version: ${{ matrix.kubernetes }}
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: --force

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -21,9 +21,14 @@ on:
   pull_request:
   schedule:
     - cron: '0 1 * * *' # Every day at 1
+  workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   JKUBE_REPOSITORY: https://github.com/eclipse-jkube/jkube.git
@@ -61,4 +66,11 @@ jobs:
           cd $env:JKUBE_DIR
           $env:JKUBE_VERSION = (mvn org.apache.maven.plugins:maven-help-plugin:3.2.0:evaluate -Dexpression='project.version' -q -DforceStdout) | Out-String
           cd ..
+          $PSNativeCommandUseErrorActionPreference = $false
+          $start = Get-Date
           mvn -B -PWindows clean verify -D'jkube.version'=$env:JKUBE_VERSION
+          $rc = $LASTEXITCODE
+          $seconds = [int]((Get-Date) - $start).TotalSeconds
+          $icon = if ($rc -eq 0) { ':heavy_check_mark:' } else { ':x:' }
+          "| windows-latest | Windows | ${seconds}s | $icon |" | Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append
+          exit $rc

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -27,7 +27,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Include the event name so a push to main does not cancel the in-flight
+  # nightly schedule run (both resolve github.ref to refs/heads/main).
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
   cancel-in-progress: true
 
 env:

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <camel.version>2.25.4</camel.version>
     <com.fasterxml.jackson.core.version>2.15.2</com.fasterxml.jackson.core.version>
     <com.fasterxml.jackson.dataformat.yaml.version>2.15.2</com.fasterxml.jackson.dataformat.yaml.version>
-    <fabric8.kubernetes-client.version>7.0.1</fabric8.kubernetes-client.version>
+    <fabric8.kubernetes-client.version>7.8.0</fabric8.kubernetes-client.version>
     <guava.version>32.1.2-jre</guava.version> <!-- Required by Gradle Test Toolkit (testkit) -->
     <gradle.version>8.14.5</gradle.version>
     <gradle-api-maven-plugin-version>0.0.3</gradle-api-maven-plugin-version>


### PR DESCRIPTION
## Summary

Applies the E2E-pipeline improvements from #409 to the workflows in this
repository, converging them with the sibling `eclipse-jkube/ci`
orchestrator (mirrored in a separate change).

## Changes (N1–N5)

- **N1 — manual re-trigger:** `workflow_dispatch` added to `e2e-tests.yml`
  and `windows-tests.yml`.
- **N2 — drop superseded runs:** `concurrency` + `cancel-in-progress`
  keyed on `github.ref`.
- **N3 — measurable regressions:** each test step appends a
  `| k8s | suite | duration | status |` row to `$GITHUB_STEP_SUMMARY`
  (bash for Linux, PowerShell for Windows).
- **N4 — cross-run caching:** `build-jkube.yml` resolves JKube master's
  commit SHA via `git ls-remote`, keys the JKube-build cache on it, and
  splits third-party Maven dependencies onto a stable `m2-` cache with
  `restore-keys`. The SHA is exposed as a reusable-workflow output and
  restored by every matrix job (m2 first so the SHA-keyed cache wins for
  `org/eclipse/jkube`). The obsolete `run-id` input is removed and all
  callers (`e2e-tests.yml`, `e2e-crc-okd-tests.yml`,
  `openshift-osci.yml.wip`) updated.
- **N5 — modern matrix:** the two EOL Kubernetes matrices are collapsed
  into `[v1.36.2, v1.35.6, v1.34.9, v1.30.14]` (3 supported + 1 legacy
  anchor); `manusa/actions-setup-minikube` bumped to v2.18.0 and minikube
  to v1.38.1. `smoke-tests.yml` keeps a lean `[v1.36.2, v1.34.9]` matrix.

## Validation

- `actionlint` passes on all changed workflows (only the pre-existing
  `if: false` on the disabled OpenShift job remains).
- Minikube action pin `b652760…` verified to equal tag `v2.18.0`.
- A live `workflow_dispatch` run is still needed to confirm all four
  Kubernetes versions provision on minikube v1.38.1 and that cross-run
  cache hits land as expected.

Refs #409