### PR TITLE
test: enable jkube.java.version integration tests

### DIFF
--- a/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/KubernetesClientAssertion.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/KubernetesClientAssertion.java
@@ -41,7 +41,7 @@ public class KubernetesClientAssertion<T extends KubernetesResource> {
       try {
         return jKubeCase.httpGet(url);
       } catch (Exception e) {
-        log.warn("Connection to {} failed, retrying", url);
+        log.warn("Connection to {} failed, retrying", url, e);
       }
       return null;
     }, 3000L).apply(Objects::nonNull);

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/KubernetesClientAssertion.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/assertions/KubernetesClientAssertion.java
@@ -41,7 +41,7 @@ public class KubernetesClientAssertion<T extends KubernetesResource> {
       try {
         return jKubeCase.httpGet(url);
       } catch (Exception e) {
-        log.warn("Connection to {} failed, retrying", url, e);
+        log.warn("Connection to {} failed, retrying", url);
       }
       return null;
     }, 3000L).apply(Objects::nonNull);

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/javaversion/JavaVersionGradle.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/javaversion/JavaVersionGradle.java
@@ -19,7 +19,6 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 import org.eclipse.jkube.integrationtests.gradle.JKubeGradleRunner;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -42,8 +41,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
 
-// TODO(eclipse-jkube/jkube#3931): remove @Disabled once merged
-@Disabled("Pending jkube.java.version support — eclipse-jkube/jkube#3931")
 @Tag(KUBERNETES)
 @TestMethodOrder(OrderAnnotation.class)
 @KubernetesTest(createEphemeralNamespace = false)

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/javaversion/JavaVersionMaven.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/javaversion/JavaVersionMaven.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.client.dsl.ExecWatch;
 import org.eclipse.jkube.integrationtests.JKubeCase;
 import org.eclipse.jkube.integrationtests.maven.MavenCase;
 import org.eclipse.jkube.integrationtests.maven.MavenInvocationResult;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
@@ -44,8 +43,6 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.matchesPattern;
 import static org.junit.jupiter.api.parallel.ResourceAccessMode.READ_WRITE;
 
-// TODO(eclipse-jkube/jkube#3931): remove @Disabled once merged
-@Disabled("Pending jkube.java.version support — eclipse-jkube/jkube#3931")
 @Tag(KUBERNETES)
 @TestMethodOrder(OrderAnnotation.class)
 @KubernetesTest(createEphemeralNamespace = false)

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/javaversion/JavaVersionK8sGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/javaversion/JavaVersionK8sGradleITCase.java
@@ -17,10 +17,6 @@ import org.eclipse.jkube.integrationtests.gradle.JKubeGradleRunner;
 import org.eclipse.jkube.integrationtests.javaversion.JavaVersionGradle;
 import org.eclipse.jkube.integrationtests.jupiter.api.Application;
 import org.eclipse.jkube.integrationtests.jupiter.api.Gradle;
-import org.junit.jupiter.api.Disabled;
-
-// TODO(eclipse-jkube/jkube#3931): remove @Disabled once merged
-@Disabled("Pending jkube.java.version support — eclipse-jkube/jkube#3931")
 @Application("qk-java-version")
 class JavaVersionK8sGradleITCase extends JavaVersionGradle {
 

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/javaversion/JavaVersionK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/quarkus/rest/javaversion/JavaVersionK8sITCase.java
@@ -14,10 +14,6 @@
 package org.eclipse.jkube.integrationtests.quarkus.rest.javaversion;
 
 import org.eclipse.jkube.integrationtests.javaversion.JavaVersionMaven;
-import org.junit.jupiter.api.Disabled;
-
-// TODO(eclipse-jkube/jkube#3931): remove @Disabled once merged
-@Disabled("Pending jkube.java.version support — eclipse-jkube/jkube#3931")
 class JavaVersionK8sITCase extends JavaVersionMaven {
 
   @Override

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/javaversion/JavaVersionK8sGradleITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/javaversion/JavaVersionK8sGradleITCase.java
@@ -17,10 +17,6 @@ import org.eclipse.jkube.integrationtests.gradle.JKubeGradleRunner;
 import org.eclipse.jkube.integrationtests.javaversion.JavaVersionGradle;
 import org.eclipse.jkube.integrationtests.jupiter.api.Application;
 import org.eclipse.jkube.integrationtests.jupiter.api.Gradle;
-import org.junit.jupiter.api.Disabled;
-
-// TODO(eclipse-jkube/jkube#3931): remove @Disabled once merged
-@Disabled("Pending jkube.java.version support — eclipse-jkube/jkube#3931")
 @Application("sb-java-version")
 class JavaVersionK8sGradleITCase extends JavaVersionGradle {
 

--- a/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/javaversion/JavaVersionK8sITCase.java
+++ b/it/src/test/java/org/eclipse/jkube/integrationtests/springboot/javaversion/JavaVersionK8sITCase.java
@@ -14,10 +14,6 @@
 package org.eclipse.jkube.integrationtests.springboot.javaversion;
 
 import org.eclipse.jkube.integrationtests.javaversion.JavaVersionMaven;
-import org.junit.jupiter.api.Disabled;
-
-// TODO(eclipse-jkube/jkube#3931): remove @Disabled once merged
-@Disabled("Pending jkube.java.version support — eclipse-jkube/jkube#3931")
 class JavaVersionK8sITCase extends JavaVersionMaven {
 
   @Override


### PR DESCRIPTION
## Summary
- Remove `@Disabled` annotations and TODO comments from 6 java-version integration test files now that [eclipse-jkube/jkube#3931](https://github.com/eclipse-jkube/jkube/pull/3931) has been merged upstream
- Enables Spring Boot and Quarkus java-version tests for both Maven and Gradle

## Test plan
- [x] Verify `springboot/javaversion` Maven and Gradle tests run and pass on CI
- [x] Verify `quarkus/rest/javaversion` Maven and Gradle tests run and pass on CI